### PR TITLE
첫 화면에 프로젝트 노드 생성 #6

### DIFF
--- a/client/src/components/atoms/Background/index.tsx
+++ b/client/src/components/atoms/Background/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
 
 interface IProps {
   width?: string;
   height?: string;
-  children?: HTMLElement | ReactJSXElement;
+  children?: React.ReactNode;
 }
 
 const WhiteBackground = styled.div<IProps>`

--- a/client/src/components/atoms/Node/index.tsx
+++ b/client/src/components/atoms/Node/index.tsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+
+enum NODE_TYPE {
+  PROJECT,
+  EPIC,
+  STORY,
+  TASK,
+}
+
+interface IProps {
+  nodeType: 'PROJECT' | 'EPIC' | 'STORY' | 'TASK';
+}
+
+const Node = styled.div<IProps>`
+  background-color: ${(props) => props.theme.nodeBgColors[NODE_TYPE[props.nodeType]]};
+  color: ${(props) => props.theme.nodeColors[NODE_TYPE[props.nodeType]]};
+  border: none;
+  border-radius: 15px;
+  text-align: center;
+  height: 44px;
+  font-size: ${(props) => props.theme.nodeFontSizes[NODE_TYPE[props.nodeType]]};
+  position: absolute;
+`;
+
+export default Node;

--- a/client/src/components/atoms/Node/index.tsx
+++ b/client/src/components/atoms/Node/index.tsx
@@ -1,25 +1,24 @@
 import styled from '@emotion/styled';
+import { levels } from 'recoil/mindMap';
 
-enum NODE_TYPE {
-  PROJECT,
+enum LEVEL {
+  ROOT,
   EPIC,
   STORY,
   TASK,
 }
 
 interface IProps {
-  nodeType: 'PROJECT' | 'EPIC' | 'STORY' | 'TASK';
+  level: levels;
 }
 
 const Node = styled.div<IProps>`
-  background-color: ${(props) => props.theme.nodeBgColors[NODE_TYPE[props.nodeType]]};
-  color: ${(props) => props.theme.nodeColors[NODE_TYPE[props.nodeType]]};
-  border: none;
-  border-radius: 15px;
-  text-align: center;
-  height: 44px;
-  font-size: ${(props) => props.theme.nodeFontSizes[NODE_TYPE[props.nodeType]]};
-  position: absolute;
+  background-color: ${(props) => props.theme.nodeBgColors[LEVEL[props.level as levels]]};
+  color: ${(props) => props.theme.nodeColors[LEVEL[props.level as levels]]};
+  border-radius: 0.5rem;
+  font-size: ${(props) => props.theme.nodeFontSizes[LEVEL[props.level as levels]]};
+  line-height: ${(props) => props.theme.nodeFontSizes[LEVEL[props.level as levels]]};
+  padding: 0.5rem 1rem;
 `;
 
 export default Node;

--- a/client/src/components/molecules/MindmapBackground/index.tsx
+++ b/client/src/components/molecules/MindmapBackground/index.tsx
@@ -1,13 +1,6 @@
 import { useEffect, useRef } from 'react';
-import styled from '@emotion/styled';
-import { ReactJSXElement } from '@emotion/react/types/jsx-namespace';
 import Background from 'components/atoms/Background';
-import { numToPx } from 'utils/helpers';
-
-enum MINDMAP_BG_SIZE {
-  WIDTH = 5000,
-  HEIGHT = 5000,
-}
+import { getCenterCoord, MINDMAP_BG_SIZE, numToPx } from 'utils/helpers';
 
 interface ICoord {
   clientX: number;
@@ -15,8 +8,10 @@ interface ICoord {
 }
 
 interface IProps {
-  children?: HTMLElement | ReactJSXElement;
+  children?: React.ReactNode;
 }
+
+const [centerX, centerY] = getCenterCoord(window.innerWidth, window.innerHeight);
 
 const MindmapBackground = ({ children }: IProps) => {
   const lastCoord = useRef<ICoord | null>(null);
@@ -69,9 +64,6 @@ const MindmapBackground = ({ children }: IProps) => {
   };
 
   useEffect(() => {
-    const centerX = (MINDMAP_BG_SIZE.WIDTH - window.innerWidth) / 2;
-    const centerY = (MINDMAP_BG_SIZE.HEIGHT - window.innerHeight) / 2;
-
     window.scrollTo(centerX, centerY);
     addListeners();
 

--- a/client/src/components/molecules/MindmapTree/index.tsx
+++ b/client/src/components/molecules/MindmapTree/index.tsx
@@ -1,21 +1,7 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { IMindNode, IMindMap } from 'recoil/mindMap';
-
-///분업을 위한 임시 지정 삭제예정
-interface INodeProps {
-  nodeId: number;
-  level: string;
-}
-
-const Node = styled.div<INodeProps>`
-  width: 5rem;
-  height: 2.5rem;
-  cursor: pointer;
-  background-color: ${(props) =>
-    props.level === 'epic' ? 'red' : props.level === 'story' ? 'yellow' : props.level === 'task' ? 'skyblue' : 'purple'};
-`;
-///분업을 위한 임시 지정 삭제예정
+import Node from 'components/atoms/Node';
 
 interface IProps {
   mindMap: IMindMap;
@@ -43,7 +29,7 @@ const getNodeContainer = (nodeId: number, mindNodes: Map<number, IMindNode>) => 
   const { level, content, children } = node!;
   return (
     <NodeContainer key={nodeId} isRoot={isRoot} draggable='true'>
-      <Node nodeId={nodeId} level={level}>
+      <Node id={nodeId.toString()} level={level}>
         {content}
       </Node>
       <ChildContainer>{children.map((childrenId) => getNodeContainer(childrenId, mindNodes))}</ChildContainer>

--- a/client/src/pages/Mindmap/index.tsx
+++ b/client/src/pages/Mindmap/index.tsx
@@ -20,19 +20,19 @@ const getDummyMindmap = (): IMindMap => {
   const mindNodes = new Map();
   Array(10)
     .fill(0)
-    .map((v, i) => ({ nodeId: i + 10, level: 'task', content: 'task', children: [] }))
+    .map((v, i) => ({ nodeId: i + 10, level: 'TASK', content: 'TASK', children: [] }))
     .forEach((v) => mindNodes.set(v.nodeId, v));
   [
-    { nodeId: 9, level: 'story', content: 'story', children: [10, 11] },
-    { nodeId: 8, level: 'story', content: 'story', children: [12, 19] },
-    { nodeId: 7, level: 'story', content: 'story', children: [] },
-    { nodeId: 6, level: 'story', content: 'story', children: [13, 14, 15] },
-    { nodeId: 5, level: 'story', content: 'story', children: [16] },
-    { nodeId: 4, level: 'story', content: 'story', children: [17, 18] },
-    { nodeId: 3, level: 'epic', content: 'epic', children: [] },
-    { nodeId: 2, level: 'epic', content: 'epic', children: [4, 5, 6, 7] },
-    { nodeId: 1, level: 'epic', content: 'epic', children: [8, 9] },
-    { nodeId: 0, level: 'root', content: 'root', children: [1, 2, 3] },
+    { nodeId: 9, level: 'STORY', content: 'STORY', children: [10, 11] },
+    { nodeId: 8, level: 'STORY', content: 'STORY', children: [12, 19] },
+    { nodeId: 7, level: 'STORY', content: 'STORY', children: [] },
+    { nodeId: 6, level: 'STORY', content: 'STORY', children: [13, 14, 15] },
+    { nodeId: 5, level: 'STORY', content: 'STORY', children: [16] },
+    { nodeId: 4, level: 'STORY', content: 'STORY', children: [17, 18] },
+    { nodeId: 3, level: 'EPIC', content: 'EPIC', children: [] },
+    { nodeId: 2, level: 'EPIC', content: 'EPIC', children: [4, 5, 6, 7] },
+    { nodeId: 1, level: 'EPIC', content: 'EPIC', children: [8, 9] },
+    { nodeId: 0, level: 'ROOT', content: 'ROOT', children: [1, 2, 3] },
   ].forEach((v) => mindNodes.set(v.nodeId, v));
   return {
     rootId: 0,

--- a/client/src/recoil/mindMap/index.ts
+++ b/client/src/recoil/mindMap/index.ts
@@ -1,8 +1,10 @@
 import { atom } from 'recoil';
 
+export type levels = 'ROOT' | 'EPIC' | 'STORY' | 'TASK';
+
 export interface IMindNode {
   nodeId: number;
-  level: string;
+  level: levels;
   content: string;
   children: Array<number>;
 }
@@ -15,7 +17,7 @@ export interface IMindMap {
 const initRootId = 0;
 const initRootNode = {
   nodeId: initRootId,
-  level: 'root',
+  level: 'ROOT' as levels,
   content: '',
   children: [],
 };

--- a/client/src/styles/common.ts
+++ b/client/src/styles/common.ts
@@ -1,4 +1,16 @@
-export type TColor = 'primary1' | 'primary2' | 'primary3' | 'red' | 'bgWhite' | 'white' | 'black' | 'gray1' | 'gray2' | 'gray3';
+export type TColor =
+  | 'primary1'
+  | 'primary2'
+  | 'primary3'
+  | 'red'
+  | 'bgWhite'
+  | 'white'
+  | 'black'
+  | 'gray1'
+  | 'gray2'
+  | 'gray3'
+  | 'yellow'
+  | 'mint';
 export type TFontSize = 'small' | 'normal' | 'large' | 'xlarge' | 'xxlarge' | 'xxxlarge' | 'title';
 export type TSize = 'small' | 'normal' | 'large' | 'xlarge' | 'xxlarge' | 'xxxlarge';
 export type TFlex = 'center' | 'rowCenter' | 'columnCenter' | 'row' | 'column';
@@ -7,7 +19,9 @@ const color: { [key in TColor]: string } = {
   primary1: '#5865F2',
   primary2: '#0A127C',
   primary3: '#BDD4E0',
-  red: '#EB5F52',
+  red: '#FF5656',
+  yellow: '#FBED6F',
+  mint: '#9BE3E3',
   bgWhite: '#F6F6F6',
   white: '#FFFFFF',
   black: '#222222',
@@ -81,6 +95,10 @@ const absoluteCenter = `
   transform: translate(-50%, -50%);
   `;
 
+const nodeBgColors = [color.primary1, color.red, color.yellow, color.mint];
+const nodeColors = [color.white, color.white, color.black, color.black];
+const nodeFontSizes = [fontSize.large, fontSize.normal, fontSize.small, fontSize.small];
+
 const common = {
   color,
   fontSize,
@@ -89,6 +107,9 @@ const common = {
   flex,
   shadow,
   absoluteCenter,
+  nodeBgColors,
+  nodeColors,
+  nodeFontSizes,
 };
 
 export default common;

--- a/client/src/styles/emotion.d.ts
+++ b/client/src/styles/emotion.d.ts
@@ -20,5 +20,8 @@ declare module '@emotion/react' {
     };
     shadow: string;
     absoluteCenter: string;
+    nodeBgColors: string[];
+    nodeColors: string[];
+    nodeFontSizes: string[];
   }
 }

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -1,4 +1,18 @@
+enum MINDMAP_BG_SIZE {
+  WIDTH = 5000,
+  HEIGHT = 5000,
+}
+
 const pxToNum = (px: string): number => Number(px.slice(0, -2));
 const numToPx = (num: number): string => num + 'px';
+const getCenterCoord = (width: number, height: number): number[] => [
+  (MINDMAP_BG_SIZE.WIDTH - width) / 2,
+  (MINDMAP_BG_SIZE.HEIGHT - height) / 2,
+];
 
-export { pxToNum, numToPx };
+const getKoreans = (str: string): [string, RegExpMatchArray] => [str, str.match(/[가-힣]/g) ?? []];
+const splitEnAndKo = ([str, koreans]: [string, RegExpMatchArray]): [number, number] => [str.length - koreans.length, koreans.length];
+const calculateWidth = ([en, ko]: [number, number]): number => en * 9 + ko * 18 + 20;
+const getNodeWidth = (str: string) => calculateWidth(splitEnAndKo(getKoreans(str)));
+
+export { pxToNum, numToPx, getCenterCoord, getNodeWidth, MINDMAP_BG_SIZE };


### PR DESCRIPTION
## 📑 제목
첫 화면에 프로젝트 노드 생성
## 📎 관련 이슈
- #6 
## ✔️ 셀프 체크리스트
- [x] 첫 화면에 프로젝트 노드 하나가 생성된다.
## 💬 작업 내용
- 루트(프로젝트) 노드 생성
- 다른 노드 작업들과 병합하며 리팩토링
## 🚧 PR 특이 사항
- 잘못된 접근으로 빙빙 돌아감...
- 노드 크기를 통해 정중앙에 위치시키는 로직을 생각하며 여러가지 유틸함수들을 만들었지만 transfrom을 통해 쉽게 구현할 수 있었음.
- 노드에만 쓰이는 theme들을 묶어 enum을 통해 관리
## 🕰 실제 소요 시간
8h