### PR TITLE
버그 수정 : 마인드맵 이동하는 방향 수정, 타겟 설정 #35

### DIFF
--- a/client/src/components/atoms/Background/index.tsx
+++ b/client/src/components/atoms/Background/index.tsx
@@ -5,6 +5,7 @@ interface IProps {
   width?: string;
   height?: string;
   children?: React.ReactNode;
+  id?: string;
 }
 
 const WhiteBackground = styled.div<IProps>`
@@ -14,9 +15,9 @@ const WhiteBackground = styled.div<IProps>`
   height: ${(props) => props.height};
 `;
 
-const Background = ({ width = '100vw', height = '100vh', children }: IProps) => {
+const Background = ({ width = '100vw', height = '100vh', children, id }: IProps) => {
   return (
-    <WhiteBackground width={width} height={height}>
+    <WhiteBackground id={id} width={width} height={height}>
       {children}
     </WhiteBackground>
   );

--- a/client/src/components/molecules/MindmapBackground/index.tsx
+++ b/client/src/components/molecules/MindmapBackground/index.tsx
@@ -39,8 +39,8 @@ const MindmapBackground = ({ children }: IProps) => {
         timer.current = null;
 
         if (!lastCoord.current) return;
-        const diffX = clientX - lastCoord.current.clientX;
-        const diffY = clientY - lastCoord.current.clientY;
+        const diffX = lastCoord.current.clientX - clientX;
+        const diffY = lastCoord.current.clientY - clientY;
 
         window.scrollBy(diffX, diffY);
         lastCoord.current = { clientX, clientY };

--- a/client/src/components/molecules/MindmapBackground/index.tsx
+++ b/client/src/components/molecules/MindmapBackground/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import Background from 'components/atoms/Background';
 import { getCenterCoord, MINDMAP_BG_SIZE, numToPx } from 'utils/helpers';
 
@@ -20,18 +20,18 @@ const MindmapBackground = ({ children }: IProps) => {
 
   const toggleDraggable = () => (draggable.current = !draggable.current);
 
-  const handleWindowMouseDown = ({ clientX, clientY, target }: MouseEvent) => {
+  const handleWindowMouseDown = useCallback(({ clientX, clientY, target }: MouseEvent) => {
     if ((target as HTMLElement).id !== 'mindmapBackground') return;
     toggleDraggable();
     lastCoord.current = { clientX, clientY };
-  };
+  }, []);
 
-  const handleWindowMouseUp = () => {
+  const handleWindowMouseUp = useCallback(() => {
     toggleDraggable();
     lastCoord.current = null;
-  };
+  }, []);
 
-  const handleWindowMouseMove = ({ clientX, clientY }: MouseEvent) => {
+  const handleWindowMouseMove = useCallback(({ clientX, clientY }: MouseEvent) => {
     if (!draggable.current || !lastCoord.current) return;
     if (timer.current) return;
 
@@ -50,26 +50,26 @@ const MindmapBackground = ({ children }: IProps) => {
       clientX,
       clientY
     );
-  };
+  }, []);
 
-  const addListeners = () => {
+  const addListeners = useCallback(() => {
     window.addEventListener('mousedown', handleWindowMouseDown);
     window.addEventListener('mousemove', handleWindowMouseMove);
     window.addEventListener('mouseup', handleWindowMouseUp);
-  };
+  }, [handleWindowMouseDown, handleWindowMouseMove, handleWindowMouseUp]);
 
-  const removeListeners = () => {
+  const removeListeners = useCallback(() => {
     window.removeEventListener('mousedown', handleWindowMouseDown);
     window.removeEventListener('mousemove', handleWindowMouseMove);
     window.removeEventListener('mouseup', handleWindowMouseUp);
-  };
+  }, [handleWindowMouseDown, handleWindowMouseMove, handleWindowMouseUp]);
 
   useEffect(() => {
     window.scrollTo(centerX, centerY);
     addListeners();
 
     return removeListeners;
-  }, []);
+  }, [addListeners, removeListeners]);
 
   return (
     <Background id={'mindmapBackground'} width={numToPx(MINDMAP_BG_SIZE.WIDTH)} height={numToPx(MINDMAP_BG_SIZE.HEIGHT)}>

--- a/client/src/components/molecules/MindmapBackground/index.tsx
+++ b/client/src/components/molecules/MindmapBackground/index.tsx
@@ -20,7 +20,8 @@ const MindmapBackground = ({ children }: IProps) => {
 
   const toggleDraggable = () => (draggable.current = !draggable.current);
 
-  const handleWindowMouseDown = ({ clientX, clientY }: MouseEvent) => {
+  const handleWindowMouseDown = ({ clientX, clientY, target }: MouseEvent) => {
+    if ((target as HTMLElement).id !== 'mindmapBackground') return;
     toggleDraggable();
     lastCoord.current = { clientX, clientY };
   };
@@ -45,7 +46,7 @@ const MindmapBackground = ({ children }: IProps) => {
         window.scrollBy(diffX, diffY);
         lastCoord.current = { clientX, clientY };
       },
-      30,
+      20,
       clientX,
       clientY
     );
@@ -71,7 +72,7 @@ const MindmapBackground = ({ children }: IProps) => {
   }, []);
 
   return (
-    <Background width={numToPx(MINDMAP_BG_SIZE.WIDTH)} height={numToPx(MINDMAP_BG_SIZE.HEIGHT)}>
+    <Background id={'mindmapBackground'} width={numToPx(MINDMAP_BG_SIZE.WIDTH)} height={numToPx(MINDMAP_BG_SIZE.HEIGHT)}>
       {children}
     </Background>
   );


### PR DESCRIPTION
## 📑 제목
버그 수정 : 마인드맵 이동하는 방향 수정, 타겟 설정
## 📎 관련 이슈
- #35 
## ✔️ 셀프 체크리스트
- [x] 스크롤 방향 반대로 설정
- [x] 마우스 이벤트 타겟 필터링
## 💬 작업 내용
스크롤 방향 반대로 변경
마우스 이벤트 타겟 id 추가해 필터링
es-lint warning 제거하기 위해 useEffect 내 dependency 추가, useCallback 전환
## 🚧 PR 특이 사항
컴포넌트가 생성될 때 한번만 이벤트핸들러 달아주고, 컴포넌트가 사라질때 이벤트핸들러 제거해주면 된다고 생각하는데, depency 배열에 함수들을 추가해야 하는지 의문임.
useCallback에 추가해줄 dependency가 없는데 useCallback으로 전환하는게 맞는지 의문임.
useCallback을 더 공부해봐야 할 듯.
## 🕰 실제 소요 시간
0.5h