### PR TITLE
헤더 바 구현 & 노드 이동 구현 #10 #20

### DIFF
--- a/client/src/App/index.tsx
+++ b/client/src/App/index.tsx
@@ -5,6 +5,7 @@ import { LoginPage, KanbanPage, ProjectPage, MindmapPage, CalendarPage, ChartPag
 import { common, global } from 'styles';
 import GlobalModal from 'components/templates/GlobalModal';
 import { Toast } from 'components/atoms';
+import { Header } from 'components/molecules';
 
 const App = () => {
   return (
@@ -13,11 +14,13 @@ const App = () => {
         <Global styles={global} />
         <Switch>
           <Route path='/' exact component={LoginPage} />
-          <Route path='/project' component={ProjectPage} />
-          <Route path='/mindmap/:roomId' component={MindmapPage} />
-          <Route path='/kanban/:roomId' component={KanbanPage} />
-          <Route path='/calendar/:roomId' component={CalendarPage} />
-          <Route path='/chart/:roomId' component={ChartPage} />
+          <Header>
+            <Route path='/project' component={ProjectPage} />
+            <Route path='/mindmap/:roomId' component={MindmapPage} />
+            <Route path='/kanban/:roomId' component={KanbanPage} />
+            <Route path='/calendar/:roomId' component={CalendarPage} />
+            <Route path='/chart/:roomId' component={ChartPage} />
+          </Header>
           <Redirect from='*' to='/' />
         </Switch>
         <GlobalModal />

--- a/client/src/components/atoms/Node/index.tsx
+++ b/client/src/components/atoms/Node/index.tsx
@@ -12,7 +12,7 @@ interface IProps {
   level: levels;
 }
 
-const Node = styled.div<IProps>`
+const Node = styled.p<IProps>`
   background-color: ${(props) => props.theme.nodeBgColors[LEVEL[props.level as levels]]};
   color: ${(props) => props.theme.nodeColors[LEVEL[props.level as levels]]};
   border-radius: 0.5rem;

--- a/client/src/components/atoms/Node/index.tsx
+++ b/client/src/components/atoms/Node/index.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { levels } from 'recoil/mindMap';
+import { levels } from 'recoil/mindmap';
 
 enum LEVEL {
   ROOT,

--- a/client/src/components/atoms/svgCurve/index.tsx
+++ b/client/src/components/atoms/svgCurve/index.tsx
@@ -1,0 +1,6 @@
+const svgCurve = () => {
+  //from to curve
+  return <svg></svg>;
+};
+
+export default svgCurve;

--- a/client/src/components/molecules/Header/index.tsx
+++ b/client/src/components/molecules/Header/index.tsx
@@ -31,6 +31,7 @@ const BoxLink = styled.div`
 
 const Header: React.FC<IProps> = ({ children }: IProps) => {
   const history = useHistory();
+
   const handleLinkClick = (link: any) => {
     history.push(link);
   };

--- a/client/src/components/molecules/Header/index.tsx
+++ b/client/src/components/molecules/Header/index.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import * as img from 'img';
+import styled from '@emotion/styled';
+import { useHistory } from 'react-router';
+
+interface IProps {
+  children?: React.ReactNode;
+}
+const BackIcon = styled.img`
+  padding: ${(props) => props.theme.padding.normal};
+  cursor: pointer;
+`;
+
+const HeaderContainer = styled.div`
+  position: fixed;
+  z-index: 1;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  ${(props) => props.theme.flex.row};
+  align-items: center;
+  gap: 0.5rem;
+  background-color: ${(props) => props.theme.color.primary1};
+`;
+
+const BoxLink = styled.div`
+  all: unset;
+  cursor: pointer;
+  color: ${(props) => props.theme.color.white};
+`;
+
+const Header: React.FC<IProps> = ({ children }: IProps) => {
+  const history = useHistory();
+  const handleLinkClick = (link: any) => {
+    history.push(link);
+  };
+
+  return (
+    <>
+      <HeaderContainer>
+        <BackIcon src={img.back} onClick={() => history.push('/')} alt='IconImgNoHoverStyle' />
+        <BoxLink onClick={handleLinkClick.bind(null, '/mindmap/123')}>마인드맵</BoxLink>
+        <BoxLink onClick={handleLinkClick.bind(null, '/kanban/123')}>칸반보드</BoxLink>
+        <BoxLink onClick={handleLinkClick.bind(null, '/calendar/123')}>캘린더</BoxLink>
+        <BoxLink onClick={handleLinkClick.bind(null, '/chart/123')}>차트</BoxLink>
+      </HeaderContainer>
+      {children}
+    </>
+  );
+};
+
+export default Header;

--- a/client/src/components/molecules/MindmapTree/index.tsx
+++ b/client/src/components/molecules/MindmapTree/index.tsx
@@ -1,20 +1,13 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from '@emotion/styled';
-import { IMindNode, IMindMap, getNextMapState, IMindNodes } from 'recoil/mindMap';
+import { IMindmapData, IMindNodes } from 'recoil/mindmap';
 import Node from 'components/atoms/Node';
-import useSocketEmitter, { ISocketEmitter } from 'hooks/useSocketEmit';
 
 interface IProps {
-  mindMap: IMindMap;
+  mindmapData: IMindmapData;
 }
 
 interface ITreeProps {
-  nodeId: number;
-  mindNodes: IMindNodes;
-}
-
-interface ISvgTreeProps {
-  positions: { nodeId: [] };
   nodeId: number;
   mindNodes: IMindNodes;
 }
@@ -24,9 +17,9 @@ interface IStyleProps {
 }
 
 const NodeContainer = styled.div<IStyleProps>`
+  ${(props) => props.isRoot && props.theme.absoluteCenter};
   ${(props) => props.theme.flex.row};
   align-items: center;
-  ${(props) => props.isRoot && props.theme.absoluteCenter};
   gap: 1rem;
   border: 1px solid blue;
 `;
@@ -55,121 +48,10 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindNodes }) => {
   );
 };
 
-// const SvgTree: React.FC<ISvgTreeProps> = ({ positions, nodeId, mindNodes }) => {
+const MindmapTree: React.FC<IProps> = ({ mindmapData }) => {
+  const { rootId, mindNodes } = mindmapData;
 
-//   return (
-
-//   );
-// };
-
-let dragged: HTMLElement;
-
-const getRegexNumber = (nodeId: string) => {
-  return Number(nodeId.replace(/[^0-9]/g, ''));
+  return <Tree key={rootId} nodeId={rootId} mindNodes={mindNodes} />;
 };
 
-const getTargetId = (element: EventTarget) => {
-  return getRegexNumber((element as HTMLElement).id);
-};
-
-const getParentId = (element: HTMLElement) => {
-  if (element.parentNode?.parentNode) {
-    const currentParent = element.parentNode.parentNode as HTMLElement;
-    if (currentParent.id) return getTargetId(currentParent);
-  }
-  return 0;
-};
-
-const handleDragStartNode = (event: MouseEvent) => {
-  dragged = event.target as HTMLElement;
-  (event.target as HTMLElement).style.opacity = '0.5';
-};
-const handleDragEndNode = (event: MouseEvent) => {
-  (event.target as HTMLElement).style.opacity = '';
-};
-const handleDragOverNode = (event: MouseEvent) => {
-  event.preventDefault();
-};
-const handleDragEnterNode = (event: MouseEvent) => {
-  if ((event.target as HTMLElement).id.match(/EPIC|STORY/)) {
-    console.log((event.target as HTMLElement).id);
-    (event.target as HTMLElement).style.background = 'purple';
-  }
-};
-const handleDragLeaveNode = (event: MouseEvent) => {
-  if ((event.target as HTMLElement).id.match(/EPIC|STORY/)) {
-    (event.target as HTMLElement).style.background = '';
-  }
-};
-const handleDropNode = (mindMap: IMindMap, socketEmitter: ISocketEmitter, event: MouseEvent) => {
-  console.log('@@@@', event);
-  event.preventDefault();
-  if ((event.target as HTMLElement).id.match(/EPIC|STORY/)) {
-    (event.target as HTMLElement).style.background = '';
-    if (event.target) {
-      const nextState = getNextMapState(mindMap);
-      const targetId = getTargetId(dragged);
-      const [oldParentId, newParentId] = [getParentId(dragged), getTargetId(event.target)];
-      if (oldParentId === newParentId) return;
-      const [oldParentNode, newParentNode] = [nextState.mindNodes.get(oldParentId), nextState.mindNodes.get(newParentId)];
-      if (oldParentNode && newParentNode) {
-        oldParentNode.children = oldParentNode.children.filter((v) => v !== targetId);
-        newParentNode.children.push(targetId);
-        console.log(targetId);
-        console.log(oldParentId, newParentId);
-        const history = {
-          oldNode: oldParentNode,
-          newNode: newParentNode,
-        };
-        socketEmitter({ eventName: 'change', history: history, nextState: nextState });
-      }
-    }
-  }
-};
-const addDragEvent = (socketEmitter: ISocketEmitter, mindMap: IMindMap) => {
-  // document.addEventListener('drag', function (event) {}, false);
-  window.addEventListener('dragstart', handleDragStartNode, false);
-  window.addEventListener('dragend', handleDragEndNode, false);
-  window.addEventListener('dragover', handleDragOverNode, false);
-  window.addEventListener('dragenter', handleDragEnterNode, false);
-  window.addEventListener('dragleave', handleDragLeaveNode, false);
-  const bindhandleDropNode = handleDropNode.bind(null, mindMap, socketEmitter);
-  window.addEventListener('drop', bindhandleDropNode, false);
-
-  const removeCallback = () => {
-    window.removeEventListener('dragstart', handleDragStartNode);
-    window.removeEventListener('dragend', handleDragEndNode);
-    window.removeEventListener('dragover', handleDragOverNode);
-    window.removeEventListener('dragenter', handleDragEnterNode);
-    window.removeEventListener('dragleave', handleDragLeaveNode);
-    window.removeEventListener('drop', bindhandleDropNode);
-  };
-  return removeCallback;
-};
-
-const MindMapTree: React.FC<IProps> = ({ mindMap }) => {
-  const { rootId, mindNodes } = mindMap;
-  const socketEmitter = useSocketEmitter();
-  // const [nodePositions, setNodePositions] = useState({});
-  // useEffect(() => {
-  //   const positions = getPositions(mindNodes);
-  //   setNodePositions(positions);
-  // }, [mindNodes]);
-  useEffect(() => {
-    const removeDragEvent = addDragEvent(socketEmitter, mindMap);
-    return () => removeDragEvent();
-  }, [socketEmitter, mindMap]);
-
-  return (
-    <>
-      <Tree key={rootId} nodeId={rootId} mindNodes={mindNodes} />
-      {/* <SvgTree positions={nodePositions} nodeId={rootId} mindNodes={mindNodes} /> */}
-    </>
-  );
-};
-
-//event 적용
-//useMemo 적용
-//svg 연결
-//노드 추가 미리보기
-export default MindMapTree;
+export default MindmapTree;

--- a/client/src/components/molecules/MindmapTree/index.tsx
+++ b/client/src/components/molecules/MindmapTree/index.tsx
@@ -1,10 +1,22 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import styled from '@emotion/styled';
-import { IMindNode, IMindMap } from 'recoil/mindMap';
+import { IMindNode, IMindMap, getNextMapState, IMindNodes } from 'recoil/mindMap';
 import Node from 'components/atoms/Node';
+import useSocketEmitter, { ISocketEmitter } from 'hooks/useSocketEmit';
 
 interface IProps {
   mindMap: IMindMap;
+}
+
+interface ITreeProps {
+  nodeId: number;
+  mindNodes: IMindNodes;
+}
+
+interface ISvgTreeProps {
+  positions: { nodeId: [] };
+  nodeId: number;
+  mindNodes: IMindNodes;
 }
 
 interface IStyleProps {
@@ -12,7 +24,8 @@ interface IStyleProps {
 }
 
 const NodeContainer = styled.div<IStyleProps>`
-  ${(props) => props.theme.flex.center};
+  ${(props) => props.theme.flex.row};
+  align-items: center;
   ${(props) => props.isRoot && props.theme.absoluteCenter};
   gap: 1rem;
   border: 1px solid blue;
@@ -23,24 +36,140 @@ const ChildContainer = styled.div`
   gap: 1rem;
 `;
 
-const getNodeContainer = (nodeId: number, mindNodes: Map<number, IMindNode>) => {
+const Tree: React.FC<ITreeProps> = ({ nodeId, mindNodes }) => {
   const isRoot = nodeId === 0;
   const node = mindNodes.get(nodeId);
   const { level, content, children } = node!;
+  const id = `${level}#${nodeId}`;
   return (
-    <NodeContainer key={nodeId} isRoot={isRoot} draggable='true'>
-      <Node id={nodeId.toString()} level={level}>
+    <NodeContainer id={id} isRoot={isRoot} draggable='true'>
+      <Node id={id} level={level}>
         {content}
       </Node>
-      <ChildContainer>{children.map((childrenId) => getNodeContainer(childrenId, mindNodes))}</ChildContainer>
+      <ChildContainer>
+        {children.map((childrenId) => (
+          <Tree key={childrenId} nodeId={childrenId} mindNodes={mindNodes} />
+        ))}
+      </ChildContainer>
     </NodeContainer>
   );
 };
 
-const MindMapTree: React.FC<IProps> = ({ mindMap }) => {
-  const { rootId, mindNodes } = mindMap;
+// const SvgTree: React.FC<ISvgTreeProps> = ({ positions, nodeId, mindNodes }) => {
 
-  return getNodeContainer(rootId, mindNodes);
+//   return (
+
+//   );
+// };
+
+let dragged: HTMLElement;
+
+const getRegexNumber = (nodeId: string) => {
+  return Number(nodeId.replace(/[^0-9]/g, ''));
 };
 
+const getTargetId = (element: EventTarget) => {
+  return getRegexNumber((element as HTMLElement).id);
+};
+
+const getParentId = (element: HTMLElement) => {
+  if (element.parentNode?.parentNode) {
+    const currentParent = element.parentNode.parentNode as HTMLElement;
+    if (currentParent.id) return getTargetId(currentParent);
+  }
+  return 0;
+};
+
+const handleDragStartNode = (event: MouseEvent) => {
+  dragged = event.target as HTMLElement;
+  (event.target as HTMLElement).style.opacity = '0.5';
+};
+const handleDragEndNode = (event: MouseEvent) => {
+  (event.target as HTMLElement).style.opacity = '';
+};
+const handleDragOverNode = (event: MouseEvent) => {
+  event.preventDefault();
+};
+const handleDragEnterNode = (event: MouseEvent) => {
+  if ((event.target as HTMLElement).id.match(/EPIC|STORY/)) {
+    console.log((event.target as HTMLElement).id);
+    (event.target as HTMLElement).style.background = 'purple';
+  }
+};
+const handleDragLeaveNode = (event: MouseEvent) => {
+  if ((event.target as HTMLElement).id.match(/EPIC|STORY/)) {
+    (event.target as HTMLElement).style.background = '';
+  }
+};
+const handleDropNode = (mindMap: IMindMap, socketEmitter: ISocketEmitter, event: MouseEvent) => {
+  console.log('@@@@', event);
+  event.preventDefault();
+  if ((event.target as HTMLElement).id.match(/EPIC|STORY/)) {
+    (event.target as HTMLElement).style.background = '';
+    if (event.target) {
+      const nextState = getNextMapState(mindMap);
+      const targetId = getTargetId(dragged);
+      const [oldParentId, newParentId] = [getParentId(dragged), getTargetId(event.target)];
+      if (oldParentId === newParentId) return;
+      const [oldParentNode, newParentNode] = [nextState.mindNodes.get(oldParentId), nextState.mindNodes.get(newParentId)];
+      if (oldParentNode && newParentNode) {
+        oldParentNode.children = oldParentNode.children.filter((v) => v !== targetId);
+        newParentNode.children.push(targetId);
+        console.log(targetId);
+        console.log(oldParentId, newParentId);
+        const history = {
+          oldNode: oldParentNode,
+          newNode: newParentNode,
+        };
+        socketEmitter({ eventName: 'change', history: history, nextState: nextState });
+      }
+    }
+  }
+};
+const addDragEvent = (socketEmitter: ISocketEmitter, mindMap: IMindMap) => {
+  // document.addEventListener('drag', function (event) {}, false);
+  window.addEventListener('dragstart', handleDragStartNode, false);
+  window.addEventListener('dragend', handleDragEndNode, false);
+  window.addEventListener('dragover', handleDragOverNode, false);
+  window.addEventListener('dragenter', handleDragEnterNode, false);
+  window.addEventListener('dragleave', handleDragLeaveNode, false);
+  const bindhandleDropNode = handleDropNode.bind(null, mindMap, socketEmitter);
+  window.addEventListener('drop', bindhandleDropNode, false);
+
+  const removeCallback = () => {
+    window.removeEventListener('dragstart', handleDragStartNode);
+    window.removeEventListener('dragend', handleDragEndNode);
+    window.removeEventListener('dragover', handleDragOverNode);
+    window.removeEventListener('dragenter', handleDragEnterNode);
+    window.removeEventListener('dragleave', handleDragLeaveNode);
+    window.removeEventListener('drop', bindhandleDropNode);
+  };
+  return removeCallback;
+};
+
+const MindMapTree: React.FC<IProps> = ({ mindMap }) => {
+  const { rootId, mindNodes } = mindMap;
+  const socketEmitter = useSocketEmitter();
+  // const [nodePositions, setNodePositions] = useState({});
+  // useEffect(() => {
+  //   const positions = getPositions(mindNodes);
+  //   setNodePositions(positions);
+  // }, [mindNodes]);
+  useEffect(() => {
+    const removeDragEvent = addDragEvent(socketEmitter, mindMap);
+    return () => removeDragEvent();
+  }, [socketEmitter, mindMap]);
+
+  return (
+    <>
+      <Tree key={rootId} nodeId={rootId} mindNodes={mindNodes} />
+      {/* <SvgTree positions={nodePositions} nodeId={rootId} mindNodes={mindNodes} /> */}
+    </>
+  );
+};
+
+//event 적용
+//useMemo 적용
+//svg 연결
+//노드 추가 미리보기
 export default MindMapTree;

--- a/client/src/components/molecules/index.tsx
+++ b/client/src/components/molecules/index.tsx
@@ -2,3 +2,4 @@ export { default as IconButton } from 'components/molecules/IconButton';
 export { default as TextButton } from 'components/molecules/TextButton';
 export { default as MindmapBackground } from 'components/molecules/MindmapBackground';
 export { default as MindmapTree } from 'components/molecules/MindmapTree';
+export { default as Header } from 'components/molecules/Header';

--- a/client/src/components/organisms/LoginWrapper/index.tsx
+++ b/client/src/components/organisms/LoginWrapper/index.tsx
@@ -29,7 +29,9 @@ const LoginBox = () => {
           history.push('/project');
         }
       })
-      .catch((err) => showMessage(err.response.data.msg));
+      .catch((err) => {
+        showMessage(err.response?.data.msg);
+      });
   };
 
   const handleClickRegister = (e: React.MouseEvent) => {

--- a/client/src/components/organisms/Mindmap/index.tsx
+++ b/client/src/components/organisms/Mindmap/index.tsx
@@ -22,9 +22,12 @@ const getParentId = (element: HTMLElement) => {
   return 0;
 };
 
-const isDraggable = (event: MouseEvent) => {
-  return (event.target as HTMLElement).id.match(/EPIC|STORY|TASK/);
-};
+//elem 확인
+// document.elementFromPoint(e.clientX, e.clientY);
+
+// const isDraggable = (event: MouseEvent) => {
+//   return (event.target as HTMLElement).id.match(/EPIC|STORY|TASK/);
+// };
 
 const handleDragStartNode = (event: MouseEvent) => {
   dragged = event.target as HTMLElement;

--- a/client/src/components/organisms/Mindmap/index.tsx
+++ b/client/src/components/organisms/Mindmap/index.tsx
@@ -1,0 +1,112 @@
+import React, { useEffect } from 'react';
+import { IMindmapData, getNextMapState } from 'recoil/mindmap';
+import useSocketEmitter, { ISocketEmitter } from 'hooks/useSocketEmit';
+import MindmapTree from 'components/molecules/MindmapTree';
+
+interface IProps {
+  mindmapData: IMindmapData;
+}
+
+let dragged: HTMLElement;
+
+const getRegexNumber = (nodeId: string) => {
+  return Number(nodeId.replace(/[^0-9]/g, ''));
+};
+
+const getTargetId = (element: EventTarget) => {
+  return getRegexNumber((element as HTMLElement).id);
+};
+
+const getParentId = (element: HTMLElement) => {
+  if (element.parentNode?.parentNode) {
+    const currentParent = element.parentNode.parentNode as HTMLElement;
+    if (currentParent.id) return getTargetId(currentParent);
+  }
+  return 0;
+};
+
+const handleDragStartNode = (event: MouseEvent) => {
+  dragged = event.target as HTMLElement;
+  (event.target as HTMLElement).style.opacity = '0.5';
+};
+const handleDragEndNode = (event: MouseEvent) => {
+  (event.target as HTMLElement).style.opacity = '';
+};
+const handleDragOverNode = (event: MouseEvent) => {
+  event.preventDefault();
+};
+const handleDragEnterNode = (event: MouseEvent) => {
+  if ((event.target as HTMLElement).id.match(/EPIC|STORY/)) {
+    console.log((event.target as HTMLElement).id);
+    (event.target as HTMLElement).style.background = 'purple';
+  }
+};
+const handleDragLeaveNode = (event: MouseEvent) => {
+  if ((event.target as HTMLElement).id.match(/EPIC|STORY/)) {
+    (event.target as HTMLElement).style.background = '';
+  }
+};
+const handleDropNode = (mindmap: IMindmapData, socketEmitter: ISocketEmitter, event: MouseEvent) => {
+  event.preventDefault();
+  if ((event.target as HTMLElement).id.match(/EPIC|STORY/)) {
+    (event.target as HTMLElement).style.background = '';
+    if (event.target) {
+      const nextState = getNextMapState(mindmap);
+      const targetId = getTargetId(dragged);
+      const [oldParentId, newParentId] = [getParentId(dragged), getTargetId(event.target)];
+      if (oldParentId === newParentId) return;
+      const [oldParentNode, newParentNode] = [nextState.mindNodes.get(oldParentId), nextState.mindNodes.get(newParentId)];
+      if (oldParentNode && newParentNode) {
+        oldParentNode.children = oldParentNode.children.filter((v) => v !== targetId);
+        newParentNode.children.push(targetId);
+        const history = {
+          oldNode: oldParentNode,
+          newNode: newParentNode,
+        };
+        socketEmitter({ eventName: 'change', history: history, nextState: nextState });
+      }
+    }
+  }
+};
+
+const addDragEvent = (socketEmitter: ISocketEmitter, mindmap: IMindmapData) => {
+  // document.addEventListener('drag', function (event) {}, false);
+  window.addEventListener('dragstart', handleDragStartNode, false);
+  window.addEventListener('dragend', handleDragEndNode, false);
+  window.addEventListener('dragover', handleDragOverNode, false);
+  window.addEventListener('dragenter', handleDragEnterNode, false);
+  window.addEventListener('dragleave', handleDragLeaveNode, false);
+  const bindhandleDropNode = handleDropNode.bind(null, mindmap, socketEmitter);
+  window.addEventListener('drop', bindhandleDropNode, false);
+
+  const removeCallback = () => {
+    window.removeEventListener('dragstart', handleDragStartNode);
+    window.removeEventListener('dragend', handleDragEndNode);
+    window.removeEventListener('dragover', handleDragOverNode);
+    window.removeEventListener('dragenter', handleDragEnterNode);
+    window.removeEventListener('dragleave', handleDragLeaveNode);
+    window.removeEventListener('drop', bindhandleDropNode);
+  };
+  return removeCallback;
+};
+
+const MindMap: React.FC<IProps> = ({ mindmapData }) => {
+  const socketEmitter = useSocketEmitter();
+
+  useEffect(() => {
+    const removeDragEvent = addDragEvent(socketEmitter, mindmapData);
+    return () => removeDragEvent();
+  }, [socketEmitter, mindmapData]);
+
+  return (
+    <>
+      <MindmapTree mindmapData={mindmapData} />
+    </>
+  );
+};
+
+//event 적용
+//useMemo 적용
+//svg 연결
+//노드 추가 미리보기
+export default MindMap;

--- a/client/src/components/organisms/index.tsx
+++ b/client/src/components/organisms/index.tsx
@@ -3,3 +3,4 @@ export { default as LoginWrapper } from 'components/organisms/LoginWrapper';
 export { default as NewProjectCard } from 'components/organisms/NewProjectCard';
 export { default as ProjectCard } from 'components/organisms/ProjectCard';
 export { default as TextInputModal } from 'components/organisms/TextInputModal';
+export { default as MindmapBtnWrapper } from 'components/organisms/MindmapBtnWrapper';

--- a/client/src/components/organisms/index.tsx
+++ b/client/src/components/organisms/index.tsx
@@ -4,3 +4,4 @@ export { default as NewProjectCard } from 'components/organisms/NewProjectCard';
 export { default as ProjectCard } from 'components/organisms/ProjectCard';
 export { default as TextInputModal } from 'components/organisms/TextInputModal';
 export { default as MindmapBtnWrapper } from 'components/organisms/MindmapBtnWrapper';
+export { default as Mindmap } from 'components/organisms/Mindmap';

--- a/client/src/components/templates/Mindmap/index.tsx
+++ b/client/src/components/templates/Mindmap/index.tsx
@@ -1,0 +1,18 @@
+import { useRecoilValue } from 'recoil';
+import { mindmapState } from 'recoil/mindmap';
+import { MindmapBackground } from 'components/molecules';
+import { Mindmap } from 'components/organisms';
+
+const MindmapTemplate = () => {
+  const mindmapData = useRecoilValue(mindmapState);
+  return (
+    <>
+      <MindmapBackground>
+        <Mindmap mindmapData={mindmapData} />
+        <MindmapWrapper></MindmapWrapper>
+      </MindmapBackground>
+    </>
+  );
+};
+
+export default MindmapTemplate;

--- a/client/src/components/templates/Mindmap/index.tsx
+++ b/client/src/components/templates/Mindmap/index.tsx
@@ -1,7 +1,7 @@
 import { useRecoilValue } from 'recoil';
 import { mindmapState } from 'recoil/mindmap';
 import { MindmapBackground } from 'components/molecules';
-import { Mindmap } from 'components/organisms';
+import { Mindmap, MindmapBtnWrapper } from 'components/organisms';
 
 const MindmapTemplate = () => {
   const mindmapData = useRecoilValue(mindmapState);
@@ -9,7 +9,7 @@ const MindmapTemplate = () => {
     <>
       <MindmapBackground>
         <Mindmap mindmapData={mindmapData} />
-        <MindmapWrapper></MindmapWrapper>
+        <MindmapBtnWrapper></MindmapBtnWrapper>
       </MindmapBackground>
     </>
   );

--- a/client/src/components/templates/index.tsx
+++ b/client/src/components/templates/index.tsx
@@ -1,2 +1,3 @@
 export { default as ProjectCardContainer } from 'components/templates/ProjectCardContainer';
 export { default as NewProjectModalWrapper } from 'components/templates/NewProjectModalWrapper';
+export { default as Mindmap } from 'components/templates/Mindmap';

--- a/client/src/hooks/useSocketEmit/index.ts
+++ b/client/src/hooks/useSocketEmit/index.ts
@@ -1,0 +1,37 @@
+import { useSetRecoilState } from 'recoil';
+import { IMindMap, mindMapState } from 'recoil/mindMap';
+// import { Socket } from 'socket.io-client';
+// let socket: Socket;
+
+interface ISocketEmitterProps {
+  eventName: string;
+  history: Object;
+  nextState: IMindMap;
+}
+
+export interface ISocketEmitter {
+  ({ eventName, history, nextState }: ISocketEmitterProps): void;
+}
+
+const useSocketEmitter = () => {
+  const setMindMap = useSetRecoilState(mindMapState);
+
+  const socketEmitter = ({ eventName, history, nextState }: ISocketEmitterProps) => {
+    // 추후 소켓 연동 후 코드 수정
+    switch (eventName) {
+      case 'change':
+        // socket.emit(eventName, history, (status:number) => {
+        //   if(status===200)
+        setMindMap(nextState as IMindMap);
+        //   else
+        //     console.log('node change Error')
+        // });
+        break;
+      default:
+        break;
+    }
+  };
+
+  return socketEmitter;
+};
+export default useSocketEmitter;

--- a/client/src/hooks/useSocketEmit/index.ts
+++ b/client/src/hooks/useSocketEmit/index.ts
@@ -1,5 +1,6 @@
 import { useSetRecoilState } from 'recoil';
 import { IMindmapData, mindmapState } from 'recoil/mindmap';
+import { Socket } from 'socket.io-client';
 // import { Socket } from 'socket.io-client';
 // let socket: Socket;
 
@@ -26,6 +27,7 @@ const useSocketEmitter = () => {
         //   else
         //     console.log('node change Error')
         // });
+
         break;
       default:
         break;

--- a/client/src/hooks/useSocketEmit/index.ts
+++ b/client/src/hooks/useSocketEmit/index.ts
@@ -1,12 +1,12 @@
 import { useSetRecoilState } from 'recoil';
-import { IMindMap, mindMapState } from 'recoil/mindMap';
+import { IMindmapData, mindmapState } from 'recoil/mindmap';
 // import { Socket } from 'socket.io-client';
 // let socket: Socket;
 
 interface ISocketEmitterProps {
   eventName: string;
   history: Object;
-  nextState: IMindMap;
+  nextState: IMindmapData;
 }
 
 export interface ISocketEmitter {
@@ -14,7 +14,7 @@ export interface ISocketEmitter {
 }
 
 const useSocketEmitter = () => {
-  const setMindMap = useSetRecoilState(mindMapState);
+  const setMindMap = useSetRecoilState(mindmapState);
 
   const socketEmitter = ({ eventName, history, nextState }: ISocketEmitterProps) => {
     // 추후 소켓 연동 후 코드 수정
@@ -22,7 +22,7 @@ const useSocketEmitter = () => {
       case 'change':
         // socket.emit(eventName, history, (status:number) => {
         //   if(status===200)
-        setMindMap(nextState as IMindMap);
+        setMindMap(nextState as IMindmapData);
         //   else
         //     console.log('node change Error')
         // });

--- a/client/src/hooks/useSocketSetup/index.ts
+++ b/client/src/hooks/useSocketSetup/index.ts
@@ -1,13 +1,13 @@
 import { useRecoilState } from 'recoil';
-import { mindMapState, getNextMapState } from 'recoil/mindMap';
+import { mindmapState, getNextMapState } from 'recoil/mindmap';
 import { io } from 'socket.io-client';
 
 const useSocketSetup = () => {
   const socket = io(`${process.env.REACT_APP_SERVER}`);
-  const [mindMap, setMindMap] = useRecoilState(mindMapState);
+  const [mindmap, setMindMap] = useRecoilState(mindmapState);
   socket.on('updateHistory', (history) => {
     const { type, sideEffect } = history;
-    const nextState = getNextMapState(mindMap);
+    const nextState = getNextMapState(mindmap);
     switch (type) {
       case 'create':
         const [newMindNodeId, newMindNode] = [sideEffect[0].id, sideEffect[0]];
@@ -26,7 +26,7 @@ const useSocketSetup = () => {
 export default useSocketSetup;
 
 // 소켓 로직을 이곳에 분리하고 init하면 좋겠다.
-// mindMap 변경은 서버에서 오는 소켓 이벤트에 의해서만 일어난다.
-// 그 외 경우 mindMap은 readonly로 사용한다.
+// mindmap 변경은 서버에서 오는 소켓 이벤트에 의해서만 일어난다.
+// 그 외 경우 mindmap은 readonly로 사용한다.
 // 고민: mindmap, kanban, calendar에서 공통적으로 사용하면서
 // 최초 1회만 실행되게하려면 어떻게 해야할까?

--- a/client/src/hooks/useSocketSetup/index.ts
+++ b/client/src/hooks/useSocketSetup/index.ts
@@ -1,6 +1,5 @@
-import Mindmap from 'pages/Mindmap';
 import { useRecoilState } from 'recoil';
-import { mindMapState } from 'recoil/mindMap';
+import { mindMapState, getNextMapState } from 'recoil/mindMap';
 import { io } from 'socket.io-client';
 
 const useSocketSetup = () => {
@@ -8,10 +7,7 @@ const useSocketSetup = () => {
   const [mindMap, setMindMap] = useRecoilState(mindMapState);
   socket.on('updateHistory', (history) => {
     const { type, sideEffect } = history;
-    const nextState = {
-      ...mindMap,
-      mindNodes: new Map(mindMap.mindNodes),
-    };
+    const nextState = getNextMapState(mindMap);
     switch (type) {
       case 'create':
         const [newMindNodeId, newMindNode] = [sideEffect[0].id, sideEffect[0]];

--- a/client/src/img/back.svg
+++ b/client/src/img/back.svg
@@ -1,0 +1,3 @@
+<svg width="7" height="13" viewBox="0 0 7 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 11.5L1 6.5L6 1.5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/img/index.ts
+++ b/client/src/img/index.ts
@@ -3,9 +3,11 @@ import logoPath from './logo.png';
 import plusPath from './plus.svg';
 import clockPath from './clock.svg';
 import plusCirclePath from './plusCircle.svg';
+import backPath from './back.svg';
 
 export const share: string = sharePath;
 export const logo: string = logoPath;
 export const plus: string = plusPath;
 export const clock: string = clockPath;
 export const plusCircle: string = plusCirclePath;
+export const back: string = backPath;

--- a/client/src/pages/Mindmap/index.tsx
+++ b/client/src/pages/Mindmap/index.tsx
@@ -1,6 +1,10 @@
 import { MindmapBackground, MindmapTree } from 'components/molecules';
+<<<<<<< HEAD
 import MindmapWrapper from 'components/organisms/MindmapBtnWrapper';
 import { useRecoilValue } from 'recoil';
+=======
+// import { useRecoilValue } from 'recoil';
+>>>>>>> 2364753 (✨ 헤더바 페이지 별 분기처리 없이 라우터에 단순 구현)
 // import { mindMapState } from 'recoil/mindMap';
 import { IMindMap } from 'recoil/mindMap';
 

--- a/client/src/pages/Mindmap/index.tsx
+++ b/client/src/pages/Mindmap/index.tsx
@@ -3,7 +3,7 @@ import MindmapWrapper from 'components/organisms/MindmapBtnWrapper';
 import { useRecoilValue } from 'recoil';
 import { mindMapState } from 'recoil/mindMap';
 
-const Mindmap = () => {
+const MindmapPage = () => {
   const mindMap = useRecoilValue(mindMapState);
   return (
     <>
@@ -15,4 +15,4 @@ const Mindmap = () => {
   );
 };
 
-export default Mindmap;
+export default MindmapPage;

--- a/client/src/pages/Mindmap/index.tsx
+++ b/client/src/pages/Mindmap/index.tsx
@@ -1,16 +1,10 @@
 import { MindmapBackground, MindmapTree } from 'components/molecules';
-<<<<<<< HEAD
 import MindmapWrapper from 'components/organisms/MindmapBtnWrapper';
 import { useRecoilValue } from 'recoil';
-=======
-// import { useRecoilValue } from 'recoil';
->>>>>>> 2364753 (✨ 헤더바 페이지 별 분기처리 없이 라우터에 단순 구현)
-// import { mindMapState } from 'recoil/mindMap';
-import { IMindMap } from 'recoil/mindMap';
+import { mindMapState } from 'recoil/mindMap';
 
 const Mindmap = () => {
-  // const mindMap = useRecoilValue(mindMapState);
-  const mindMap = getDummyMindmap();
+  const mindMap = useRecoilValue(mindMapState);
   return (
     <>
       <MindmapBackground>
@@ -19,31 +13,6 @@ const Mindmap = () => {
       </MindmapBackground>
     </>
   );
-};
-
-///더미코드 삭제 예정
-const getDummyMindmap = (): IMindMap => {
-  const mindNodes = new Map();
-  Array(10)
-    .fill(0)
-    .map((v, i) => ({ nodeId: i + 10, level: 'TASK', content: 'TASK', children: [] }))
-    .forEach((v) => mindNodes.set(v.nodeId, v));
-  [
-    { nodeId: 9, level: 'STORY', content: 'STORY', children: [10, 11] },
-    { nodeId: 8, level: 'STORY', content: 'STORY', children: [12, 19] },
-    { nodeId: 7, level: 'STORY', content: 'STORY', children: [] },
-    { nodeId: 6, level: 'STORY', content: 'STORY', children: [13, 14, 15] },
-    { nodeId: 5, level: 'STORY', content: 'STORY', children: [16] },
-    { nodeId: 4, level: 'STORY', content: 'STORY', children: [17, 18] },
-    { nodeId: 3, level: 'EPIC', content: 'EPIC', children: [] },
-    { nodeId: 2, level: 'EPIC', content: 'EPIC', children: [4, 5, 6, 7] },
-    { nodeId: 1, level: 'EPIC', content: 'EPIC', children: [8, 9] },
-    { nodeId: 0, level: 'ROOT', content: 'ROOT', children: [1, 2, 3] },
-  ].forEach((v) => mindNodes.set(v.nodeId, v));
-  return {
-    rootId: 0,
-    mindNodes: mindNodes,
-  };
 };
 
 export default Mindmap;

--- a/client/src/pages/Mindmap/index.tsx
+++ b/client/src/pages/Mindmap/index.tsx
@@ -1,18 +1,7 @@
-import { MindmapBackground, MindmapTree } from 'components/molecules';
-import MindmapWrapper from 'components/organisms/MindmapBtnWrapper';
-import { useRecoilValue } from 'recoil';
-import { mindMapState } from 'recoil/mindMap';
+import MindmapTemplate from 'components/templates/Mindmap';
 
 const MindmapPage = () => {
-  const mindMap = useRecoilValue(mindMapState);
-  return (
-    <>
-      <MindmapBackground>
-        <MindmapTree mindMap={mindMap} />
-        <MindmapWrapper></MindmapWrapper>
-      </MindmapBackground>
-    </>
-  );
+  return <MindmapTemplate />;
 };
 
 export default MindmapPage;

--- a/client/src/recoil/mindMap/index.ts
+++ b/client/src/recoil/mindMap/index.ts
@@ -34,10 +34,19 @@ export interface IMindNode {
   children: Array<number>;
 }
 
+export type IMindNodes = Map<number, IMindNode>;
+
 export interface IMindMap {
   rootId: number;
-  mindNodes: Map<number, IMindNode>;
+  mindNodes: IMindNodes;
 }
+
+export const getNextMapState = (mindMap: IMindMap) => {
+  return {
+    ...mindMap,
+    mindNodes: new Map(mindMap.mindNodes),
+  };
+};
 
 // const initRootId = 0;
 // const initRootNode = {

--- a/client/src/recoil/mindMap/index.ts
+++ b/client/src/recoil/mindMap/index.ts
@@ -2,8 +2,29 @@ import { atom } from 'recoil';
 
 export type levels = 'ROOT' | 'EPIC' | 'STORY' | 'TASK';
 
+export interface IMindmapData {
+  rootId: number;
+  mindNodes: IMindNodes;
+}
+
+export interface IMindNode {
+  nodeId: number;
+  level: levels;
+  content: string;
+  children: Array<number>;
+}
+
+export type IMindNodes = Map<number, IMindNode>;
+
+export const getNextMapState = (mindmap: IMindmapData) => {
+  return {
+    ...mindmap,
+    mindNodes: new Map(mindmap.mindNodes),
+  };
+};
+
 ///더미코드 삭제 예정
-const getDummyMindmap = (): IMindMap => {
+const getDummyMindmapData = (): IMindmapData => {
   const mindNodes = new Map();
   Array(10)
     .fill(0)
@@ -27,27 +48,6 @@ const getDummyMindmap = (): IMindMap => {
   };
 };
 
-export interface IMindNode {
-  nodeId: number;
-  level: levels;
-  content: string;
-  children: Array<number>;
-}
-
-export type IMindNodes = Map<number, IMindNode>;
-
-export interface IMindMap {
-  rootId: number;
-  mindNodes: IMindNodes;
-}
-
-export const getNextMapState = (mindMap: IMindMap) => {
-  return {
-    ...mindMap,
-    mindNodes: new Map(mindMap.mindNodes),
-  };
-};
-
 // const initRootId = 0;
 // const initRootNode = {
 //   nodeId: initRootId,
@@ -56,8 +56,8 @@ export const getNextMapState = (mindMap: IMindMap) => {
 //   children: [],
 // };
 
-export const mindMapState = atom<IMindMap>({
-  key: 'mindMapAtom',
+export const mindmapState = atom<IMindmapData>({
+  key: 'mindmapAtom',
   // default: { rootId: initRootId, mindNodes: new Map([[initRootId, initRootNode]]) },
-  default: getDummyMindmap(),
+  default: getDummyMindmapData(),
 });

--- a/client/src/recoil/mindMap/index.ts
+++ b/client/src/recoil/mindMap/index.ts
@@ -2,6 +2,31 @@ import { atom } from 'recoil';
 
 export type levels = 'ROOT' | 'EPIC' | 'STORY' | 'TASK';
 
+///더미코드 삭제 예정
+const getDummyMindmap = (): IMindMap => {
+  const mindNodes = new Map();
+  Array(10)
+    .fill(0)
+    .map((v, i) => ({ nodeId: i + 10, level: 'TASK', content: 'TASK', children: [] }))
+    .forEach((v) => mindNodes.set(v.nodeId, v));
+  [
+    { nodeId: 9, level: 'STORY', content: 'STORY', children: [10, 11] },
+    { nodeId: 8, level: 'STORY', content: 'STORY', children: [12, 19] },
+    { nodeId: 7, level: 'STORY', content: 'STORY', children: [] },
+    { nodeId: 6, level: 'STORY', content: 'STORY', children: [13, 14, 15] },
+    { nodeId: 5, level: 'STORY', content: 'STORY', children: [16] },
+    { nodeId: 4, level: 'STORY', content: 'STORY', children: [17, 18] },
+    { nodeId: 3, level: 'EPIC', content: 'EPIC', children: [] },
+    { nodeId: 2, level: 'EPIC', content: 'EPIC', children: [4, 5, 6, 7] },
+    { nodeId: 1, level: 'EPIC', content: 'EPIC', children: [8, 9] },
+    { nodeId: 0, level: 'ROOT', content: 'ROOT', children: [1, 2, 3] },
+  ].forEach((v) => mindNodes.set(v.nodeId, v));
+  return {
+    rootId: 0,
+    mindNodes: mindNodes,
+  };
+};
+
 export interface IMindNode {
   nodeId: number;
   level: levels;
@@ -14,15 +39,16 @@ export interface IMindMap {
   mindNodes: Map<number, IMindNode>;
 }
 
-const initRootId = 0;
-const initRootNode = {
-  nodeId: initRootId,
-  level: 'ROOT' as levels,
-  content: '',
-  children: [],
-};
+// const initRootId = 0;
+// const initRootNode = {
+//   nodeId: initRootId,
+//   level: 'ROOT' as levels,
+//   content: '',
+//   children: [],
+// };
 
 export const mindMapState = atom<IMindMap>({
   key: 'mindMapAtom',
-  default: { rootId: initRootId, mindNodes: new Map([[initRootId, initRootNode]]) },
+  // default: { rootId: initRootId, mindNodes: new Map([[initRootId, initRootNode]]) },
+  default: getDummyMindmap(),
 });

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -15,4 +15,8 @@ const splitEnAndKo = ([str, koreans]: [string, RegExpMatchArray]): [number, numb
 const calculateWidth = ([en, ko]: [number, number]): number => en * 9 + ko * 18 + 20;
 const getNodeWidth = (str: string) => calculateWidth(splitEnAndKo(getKoreans(str)));
 
-export { pxToNum, numToPx, getCenterCoord, getNodeWidth, MINDMAP_BG_SIZE };
+const getRegexNumber = (nodeId: string) => {
+  return Number(nodeId.replace(/[^0-9]/g, ''));
+};
+
+export { pxToNum, numToPx, getCenterCoord, getNodeWidth, MINDMAP_BG_SIZE, getRegexNumber };


### PR DESCRIPTION
## 📑 제목
헤더 바 구현 & 노드 이동 구현 #10 #20

## 📎 관련 이슈
- [X] 헤더바 현재 제대로 동작 X 리팩토링 필요

## ✔️ 셀프 체크리스트
- [X] 노드를 원하는 부모로 이동할 수 있는가
- [X] 노드의 상태 변경이 UI에 즉각 반영되는가

## 💬 작업 내용
- [X] drag 이벤트 리팩토링
- [X] 노드 이동 구현
- [X] mindmap 아토믹하게 분리 및 리팩토링

## 🚧 PR 특이 사항
- [x] 앞으로 기능별로 PR 잘 나눠서 진행하겠습니다.
- [X] 데이터 흐름구조를 싹 갈아엎는데 비용이 들 것 같아서 history를 소켓으로 보내는 대략적인 틀을 만들어놨습니다.
- [X] drag관련 이벤트가 많고 아직 동작을 제대로 이해하지 못해 리팩토링을 계속 진행 중입니다.

## 🕰 실제 소요 시간
6hr
