### PR TITLE
마인드맵 로직 개선, useEvent, useDragEvent, useThrottle  커스텀 훅 정의 #10 #20 

### DIFF
--- a/client/src/components/atoms/Node/index.tsx
+++ b/client/src/components/atoms/Node/index.tsx
@@ -1,23 +1,16 @@
 import styled from '@emotion/styled';
-import { levels } from 'recoil/mindmap';
-
-enum LEVEL {
-  ROOT,
-  EPIC,
-  STORY,
-  TASK,
-}
+import { Levels, levelToIdx } from 'utils/helpers';
 
 interface IProps {
-  level: levels;
+  level: Levels;
 }
 
 const Node = styled.p<IProps>`
-  background-color: ${(props) => props.theme.nodeBgColors[LEVEL[props.level as levels]]};
-  color: ${(props) => props.theme.nodeColors[LEVEL[props.level as levels]]};
+  background-color: ${(props) => props.theme.nodeBgColors[levelToIdx(props.level)]};
+  color: ${(props) => props.theme.nodeColors[levelToIdx(props.level)]};
   border-radius: 0.5rem;
-  font-size: ${(props) => props.theme.nodeFontSizes[LEVEL[props.level as levels]]};
-  line-height: ${(props) => props.theme.nodeFontSizes[LEVEL[props.level as levels]]};
+  font-size: ${(props) => props.theme.nodeFontSizes[levelToIdx(props.level)]};
+  line-height: ${(props) => props.theme.nodeFontSizes[levelToIdx(props.level)]};
   padding: 0.5rem 1rem;
 `;
 

--- a/client/src/components/molecules/Header/index.tsx
+++ b/client/src/components/molecules/Header/index.tsx
@@ -39,7 +39,7 @@ const Header: React.FC<IProps> = ({ children }: IProps) => {
   return (
     <>
       <HeaderContainer>
-        <BackIcon src={img.back} onClick={() => history.push('/')} alt='IconImgNoHoverStyle' />
+        <BackIcon src={img.back} onClick={() => history.push('/project')} alt='IconImgNoHoverStyle' />
         <BoxLink onClick={handleLinkClick.bind(null, '/mindmap/123')}>마인드맵</BoxLink>
         <BoxLink onClick={handleLinkClick.bind(null, '/kanban/123')}>칸반보드</BoxLink>
         <BoxLink onClick={handleLinkClick.bind(null, '/calendar/123')}>캘린더</BoxLink>

--- a/client/src/hooks/useDragEvent/index.ts
+++ b/client/src/hooks/useDragEvent/index.ts
@@ -1,0 +1,65 @@
+import useEvents, { EventElems } from 'hooks/useEvents';
+import React, { useRef } from 'react';
+
+export interface IEvents {
+  [key: string]: any;
+}
+
+const useDragEvent = (events: IEvents, interactElemIds: Array<string> = [], dragEnterColor = 'none') => {
+  const draggedRef = useRef<HTMLElement | null>(null);
+  const isInteractable = (event: React.MouseEvent) => {
+    const target = event.target as HTMLElement;
+    return target.id && interactElemIds.find((elemId) => target.id.match(elemId));
+  };
+
+  const handleDragStartNode = (event: React.MouseEvent) => {
+    if (!isInteractable(event)) return;
+    draggedRef.current = event.target as HTMLElement;
+    (event.target as HTMLElement).style.opacity = '0.5';
+    if (events['dragstart']) events['dragstart'](event);
+  };
+
+  const handleDragEnterNode = (event: React.MouseEvent) => {
+    if (!isInteractable(event)) return;
+    (event.target as HTMLElement).style.background = dragEnterColor;
+    if (events['dragenter']) events['dragenter'](event);
+  };
+
+  const handleDragOverNode = (event: React.MouseEvent) => {
+    if (!isInteractable(event)) return;
+    event.preventDefault();
+    if (events['dragover']) events['dragover'](event);
+  };
+  // const throttleDragOverNode = useThrottle(handleDragOverNode, 20);
+
+  const handleDragLeaveNode = (event: React.MouseEvent) => {
+    if (!isInteractable(event)) return;
+    (event.target as HTMLElement).style.background = '';
+    if (events['dragleave']) events['dragleave'](event);
+  };
+
+  const handleDragEndNode = (event: React.MouseEvent) => {
+    if (!isInteractable(event)) return;
+    (event.target as HTMLElement).style.opacity = '';
+    draggedRef.current = null;
+    if (events['dragend']) events['dragend'](event);
+  };
+
+  const handleDrop = (event: React.MouseEvent) => {
+    if (!draggedRef.current || !isInteractable(event)) return;
+    (event.target as HTMLElement).style.background = '';
+    if (events['drop']) events['drop'](event, draggedRef.current);
+  };
+
+  const dragEvents: EventElems = [
+    ['dragstart', handleDragStartNode],
+    ['dragend', handleDragEndNode],
+    ['dragover', handleDragOverNode],
+    ['dragenter', handleDragEnterNode],
+    ['dragleave', handleDragLeaveNode],
+    ['drop', handleDrop],
+  ];
+  useEvents(dragEvents);
+};
+
+export default useDragEvent;

--- a/client/src/hooks/useEvents/index.ts
+++ b/client/src/hooks/useEvents/index.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+export type EventElem = [keyof WindowEventMap, any];
+export type EventElems = Array<EventElem>;
+
+const useEvents = (events: Array<EventElem>) => {
+  useEffect(() => {
+    events.forEach(([eventname, handler]: EventElem) => window.addEventListener(eventname, handler));
+    return () => events.forEach(([eventname, handler]: EventElem) => window.removeEventListener(eventname, handler));
+  }, [events]);
+};
+
+export default useEvents;

--- a/client/src/hooks/useSocketEmit/index.ts
+++ b/client/src/hooks/useSocketEmit/index.ts
@@ -1,6 +1,5 @@
 import { useSetRecoilState } from 'recoil';
 import { IMindmapData, mindmapState } from 'recoil/mindmap';
-import { Socket } from 'socket.io-client';
 // import { Socket } from 'socket.io-client';
 // let socket: Socket;
 

--- a/client/src/hooks/useThrottle/index.ts
+++ b/client/src/hooks/useThrottle/index.ts
@@ -1,0 +1,16 @@
+import { useRef } from 'react';
+
+const useThrottle = (callback: (...params: any) => void, time: number) => {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return () => {
+    if (!timer.current) {
+      timer.current = setTimeout(() => {
+        callback();
+        timer.current = null;
+      }, time);
+    }
+  };
+};
+
+export default useThrottle;

--- a/client/src/recoil/mindmap/index.ts
+++ b/client/src/recoil/mindmap/index.ts
@@ -1,6 +1,5 @@
 import { atom } from 'recoil';
-
-export type levels = 'ROOT' | 'EPIC' | 'STORY' | 'TASK';
+import { Levels } from 'utils/helpers';
 
 export interface IMindmapData {
   rootId: number;
@@ -9,17 +8,17 @@ export interface IMindmapData {
 
 export interface IMindNode {
   nodeId: number;
-  level: levels;
+  level: Levels;
   content: string;
   children: Array<number>;
 }
 
 export type IMindNodes = Map<number, IMindNode>;
 
-export const getNextMapState = (mindmap: IMindmapData) => {
+export const getNextMapState = (prevState: IMindmapData) => {
   return {
-    ...mindmap,
-    mindNodes: new Map(mindmap.mindNodes),
+    ...prevState,
+    mindNodes: new Map(prevState.mindNodes),
   };
 };
 
@@ -51,7 +50,7 @@ const getDummyMindmapData = (): IMindmapData => {
 // const initRootId = 0;
 // const initRootNode = {
 //   nodeId: initRootId,
-//   level: 'ROOT' as levels,
+//   level: 'ROOT' as Levels,
 //   content: '',
 //   children: [],
 // };

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -19,4 +19,10 @@ const getRegexNumber = (nodeId: string) => {
   return Number(nodeId.replace(/[^0-9]/g, ''));
 };
 
-export { pxToNum, numToPx, getCenterCoord, getNodeWidth, MINDMAP_BG_SIZE, getRegexNumber };
+export type Levels = 'ROOT' | 'EPIC' | 'STORY' | 'TASK';
+type DictType = { [index: number]: string };
+const LEVEL_DICT: DictType = { 0: 'ROOT', 1: 'EPIC', 2: 'STORY', 3: 'TASK' };
+const idxToLevel = (idx: number) => LEVEL_DICT[idx] as Levels;
+const levelToIdx = (level: string) => Object.values(LEVEL_DICT).findIndex((v) => level === v);
+
+export { pxToNum, numToPx, getCenterCoord, getNodeWidth, MINDMAP_BG_SIZE, getRegexNumber, idxToLevel, levelToIdx };


### PR DESCRIPTION
## 📑 제목
마인드맵 로직 개선, 이벤트 관련 커스텀 훅 정의 #10 #20

## 📎 관련 이슈
- #10
- #20

## ✔️ 셀프 체크리스트
- [X] Task는 상위 level로 이동할 수 없다.
- [X] 코드를 작게 분리하였다.
- [X] 코드를 알아볼 수 있게 리팩토링하였다.
- [X] 재사용할 로직들을 커스텀 훅으로 분리하였다.

## 💬 작업 내용
- useEvent, useDragEvent, useThrottle  추가
- 마인드맵 트리 이동 로직 추가
- 마인드맵 트리 리팩토링

## 🚧 PR 특이 사항
- 타입스크립트가 어려워요. 값을 인자로 넣기가 어렵네요. 나중에 리팩토링을 한 번 더 해야겠습니다.
- dragEvent를 최대한 칸반보드에도 사용할 수 있게 분리해봤습니다. 

## 🕰 실제 소요 시간
8hr