### PR TITLE
하단에 히스토리 창이 토글된다. #61

### DIFF
--- a/client/src/App/index.tsx
+++ b/client/src/App/index.tsx
@@ -1,7 +1,7 @@
 import { Route, Switch, Redirect } from 'react-router-dom';
 import { Global, ThemeProvider } from '@emotion/react';
 import { RecoilRoot } from 'recoil';
-import { LoginPage, KanbanPage, ProjectPage, MindmapPage, CalendarPage, ChartPage } from 'pages';
+import { LoginPage, KanbanPage, ProjectPage, MindmapPage, CalendarPage, ChartPage, HistoryPage } from 'pages';
 import { common, global } from 'styles';
 import GlobalModal from 'components/templates/GlobalModal';
 import { Toast } from 'components/atoms';
@@ -16,10 +16,11 @@ const App = () => {
           <Route path='/' exact component={LoginPage} />
           <Route path='/project' component={ProjectPage} />
           <Header>
-            <Route path='/mindmap/:roomId' component={MindmapPage} />
-            <Route path='/kanban/:roomId' component={KanbanPage} />
-            <Route path='/calendar/:roomId' component={CalendarPage} />
-            <Route path='/chart/:roomId' component={ChartPage} />
+            <Route path='/mindmap/:projectId' component={MindmapPage} />
+            <Route path='/history/:projectId' component={HistoryPage} />
+            <Route path='/kanban/:projectId' component={KanbanPage} />
+            <Route path='/calendar/:projectId' component={CalendarPage} />
+            <Route path='/chart/:projectId' component={ChartPage} />
           </Header>
           <Redirect from='*' to='/' />
         </Switch>

--- a/client/src/components/atoms/IconImg/index.tsx
+++ b/client/src/components/atoms/IconImg/index.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 
 interface IProps {
   imgSrc: string;
+  altText: string;
 }
 
 const StyledIconImg = styled.img`
@@ -14,8 +15,8 @@ const StyledIconImg = styled.img`
   }
 `;
 
-const IconImg: React.FC<IProps> = ({ imgSrc }) => {
-  return <StyledIconImg src={imgSrc} alt='IconImg' />;
+const IconImg: React.FC<IProps> = ({ imgSrc, altText }) => {
+  return <StyledIconImg src={imgSrc} alt={altText} />;
 };
 
 export default IconImg;

--- a/client/src/components/atoms/Title/index.tsx
+++ b/client/src/components/atoms/Title/index.tsx
@@ -6,11 +6,12 @@ interface IProps {
   titleStyle?: TStyle;
   color?: TColor;
   margin?: string;
+  lineHeight?: number;
 }
 
-const Title: React.FC<IProps> = ({ children, margin = '0.5rem 0', color = 'black', titleStyle = 'normal' }) => {
+const Title: React.FC<IProps> = ({ children, margin = '0.5rem 0', color = 'black', titleStyle = 'normal', lineHeight }) => {
   return (
-    <StyledTitle titleStyle={titleStyle} color={color} margin={margin}>
+    <StyledTitle titleStyle={titleStyle} color={color} margin={margin} lineHeight={lineHeight}>
       {children}
     </StyledTitle>
   );

--- a/client/src/components/atoms/Title/style.ts
+++ b/client/src/components/atoms/Title/style.ts
@@ -5,6 +5,7 @@ interface IStyleProps {
   titleStyle: TStyle;
   color: TColor;
   margin?: string;
+  lineHeight?: number;
 }
 
 export type TStyle = 'small' | 'normal' | 'large' | 'xlarge' | 'xxxlarge' | 'title';
@@ -15,7 +16,7 @@ export const StyledTitle = styled.div<IStyleProps>`
   ${({ color }) => colorOptions[color]}
   margin: ${({ margin }) => margin};
   font-weight: bold;
-  line-height: 1.2;
+  line-height: ${({ lineHeight }) => lineHeight ?? 1.2};
 `;
 
 const styleOptions: { [key in TStyle]: string } = {

--- a/client/src/components/molecules/HistoryLog/index.tsx
+++ b/client/src/components/molecules/HistoryLog/index.tsx
@@ -1,10 +1,10 @@
 import styled from '@emotion/styled';
-import { IconImg, Title } from 'components/atoms';
+import { Title } from 'components/atoms';
 import { IUser } from 'recoil/user';
+import { Profile } from '..';
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.flex.row};
-  gap: 0.5rem;
   width: 100%;
 `;
 
@@ -16,11 +16,8 @@ interface IPros {
 const HistoryLog: React.FC<IPros> = ({ modifier, log }) => {
   return (
     <Wrapper>
-      <IconImg imgSrc={modifier.icon} altText={modifier.name} />
-      <Title titleStyle='xlarge' color='white'>
-        {modifier.name}
-      </Title>
-      <Title titleStyle='large' color='white'>
+      <Profile user={modifier} />
+      <Title titleStyle='xlarge' color='white' margin='0 0 0 0.5rem' lineHeight={2}>
         {log}
       </Title>
     </Wrapper>

--- a/client/src/components/molecules/HistoryLog/index.tsx
+++ b/client/src/components/molecules/HistoryLog/index.tsx
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+import { IconImg, Title } from 'components/atoms';
+import { IUser } from 'recoil/user';
+
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flex.row};
+  gap: 0.5rem;
+  width: 100%;
+`;
+
+interface IPros {
+  modifier: IUser;
+  log: string;
+}
+
+const HistoryLog: React.FC<IPros> = ({ modifier, log }) => {
+  return (
+    <Wrapper>
+      <IconImg imgSrc={modifier.icon} altText={modifier.name} />
+      <Title titleStyle='xlarge' color='white'>
+        {modifier.name}
+      </Title>
+      <Title titleStyle='large' color='white'>
+        {log}
+      </Title>
+    </Wrapper>
+  );
+};
+
+export default HistoryLog;

--- a/client/src/components/molecules/HistoryWindow/index.tsx
+++ b/client/src/components/molecules/HistoryWindow/index.tsx
@@ -1,0 +1,14 @@
+import styled from '@emotion/styled';
+
+const Wrapper = styled.div`
+  background-color: ${({ theme }) => theme.color.bgWhite};
+  width: 100%;
+  margin: 0 2rem;
+  height: 70px;
+`;
+
+const HistoryWindow = () => {
+  return <Wrapper></Wrapper>;
+};
+
+export default HistoryWindow;

--- a/client/src/components/molecules/IconButton/index.tsx
+++ b/client/src/components/molecules/IconButton/index.tsx
@@ -4,12 +4,13 @@ import { IconImg, TransparentButton } from 'components/atoms';
 interface IProps {
   onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   imgSrc: string;
+  altText: string;
 }
 
-const IconButton: React.FC<IProps> = ({ onClick, imgSrc }) => {
+const IconButton: React.FC<IProps> = ({ onClick, imgSrc, altText }) => {
   return (
     <TransparentButton onClick={onClick}>
-      <IconImg imgSrc={imgSrc} />
+      <IconImg imgSrc={imgSrc} altText={altText} />
     </TransparentButton>
   );
 };

--- a/client/src/components/molecules/PlayController/index.tsx
+++ b/client/src/components/molecules/PlayController/index.tsx
@@ -1,0 +1,23 @@
+import styled from '@emotion/styled';
+import { backwardBtn, playBtn, forwardBtn } from 'img';
+import { IconButton } from '..';
+
+const PlayController = () => {
+  const handleBackwardBtnClick = () => {};
+  const handlePlayBtnClick = () => {};
+  const handleForwardBtnClick = () => {};
+
+  return (
+    <Wrapper>
+      <IconButton onClick={handleBackwardBtnClick} imgSrc={backwardBtn} />
+      <IconButton onClick={handlePlayBtnClick} imgSrc={playBtn} />
+      <IconButton onClick={handleForwardBtnClick} imgSrc={forwardBtn} />
+    </Wrapper>
+  );
+};
+
+export default PlayController;
+
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flex.row}
+`;

--- a/client/src/components/molecules/PlayController/index.tsx
+++ b/client/src/components/molecules/PlayController/index.tsx
@@ -9,9 +9,9 @@ const PlayController = () => {
 
   return (
     <Wrapper>
-      <IconButton onClick={handleBackwardBtnClick} imgSrc={backwardBtn} />
-      <IconButton onClick={handlePlayBtnClick} imgSrc={playBtn} />
-      <IconButton onClick={handleForwardBtnClick} imgSrc={forwardBtn} />
+      <IconButton onClick={handleBackwardBtnClick} imgSrc={backwardBtn} altText='처음으로 이동하기 버튼' />
+      <IconButton onClick={handlePlayBtnClick} imgSrc={playBtn} altText='재생하기 버튼' />
+      <IconButton onClick={handleForwardBtnClick} imgSrc={forwardBtn} altText='끝으로 이동하기 버튼' />
     </Wrapper>
   );
 };

--- a/client/src/components/molecules/Profile/index.tsx
+++ b/client/src/components/molecules/Profile/index.tsx
@@ -1,0 +1,19 @@
+import { IconImg, Title } from 'components/atoms';
+import { IUser } from 'recoil/user';
+
+interface IProps {
+  user: IUser;
+}
+
+const Profile: React.FC<IProps> = ({ user }) => {
+  return (
+    <>
+      <IconImg imgSrc={user.icon} altText={user.name} />
+      <Title titleStyle='xlarge' color='white'>
+        {user.name}
+      </Title>
+    </>
+  );
+};
+
+export default Profile;

--- a/client/src/components/molecules/index.tsx
+++ b/client/src/components/molecules/index.tsx
@@ -7,3 +7,4 @@ export { default as PopupLayout } from 'components/molecules/PopupLayout';
 export { default as Path } from 'components/molecules/Path';
 export { default as Tree } from 'components/molecules/Tree';
 export { default as PlayController } from 'components/molecules/PlayController';
+export { default as HistoryLog } from 'components/molecules/HistoryLog';

--- a/client/src/components/molecules/index.tsx
+++ b/client/src/components/molecules/index.tsx
@@ -8,3 +8,4 @@ export { default as Path } from 'components/molecules/Path';
 export { default as Tree } from 'components/molecules/Tree';
 export { default as PlayController } from 'components/molecules/PlayController';
 export { default as HistoryLog } from 'components/molecules/HistoryLog';
+export { default as Profile } from 'components/molecules/Profile';

--- a/client/src/components/molecules/index.tsx
+++ b/client/src/components/molecules/index.tsx
@@ -6,3 +6,4 @@ export { default as PopupItemLayout } from 'components/molecules/PopupItemLayout
 export { default as PopupLayout } from 'components/molecules/PopupLayout';
 export { default as Path } from 'components/molecules/Path';
 export { default as Tree } from 'components/molecules/Tree';
+export { default as PlayController } from 'components/molecules/PlayController';

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -6,6 +6,24 @@ import HistoryWindow from 'components/molecules/HistoryWindow';
 import { useHistory } from 'react-router';
 import useProjectId from 'hooks/useRoomId';
 
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flex.columnCenter}
+  position: fixed;
+  background-color: ${({ theme }) => theme.color.gray1};
+  width: 100vw;
+  height: 160px;
+  bottom: 0;
+  padding: 0 2rem;
+`;
+
+const UpperDiv = styled.div`
+  ${({ theme }) => theme.flex.row};
+  justify-content: space-between;
+  padding: 0 2rem;
+  width: 100%;
+  height: 45px;
+`;
+
 const HistoryBar: React.FC = () => {
   const history = useHistory();
   const projectId = useProjectId();
@@ -31,23 +49,3 @@ const HistoryBar: React.FC = () => {
 };
 
 export default HistoryBar;
-
-const Wrapper = styled.div`
-  ${({ theme }) => theme.flex.columnCenter}
-  position: fixed;
-  background-color: ${({ theme }) => theme.color.gray1};
-  width: 100vw;
-  height: 160px;
-  bottom: 0;
-  padding: 0 2rem;
-`;
-
-const UpperDiv = styled.div`
-  ${({ theme }) => theme.flex.row};
-  justify-content: space-between;
-  padding: 0 2rem;
-  width: 100%;
-  height: 45px;
-`;
-
-const topBar = styled.div``;

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+import { whiteCloseBtn } from 'img';
+import { Title } from 'components/atoms';
+import { IconButton, PlayController } from 'components/molecules';
+
+const HistoryBar: React.FC = () => {
+  const handleCloseHistoryBtnClick = () => {};
+
+  return (
+    <Wrapper>
+      <UpperDiv>
+        <Title titleStyle='xxxlarge' color='white'>
+          History
+        </Title>
+        <PlayController />
+        <IconButton imgSrc={whiteCloseBtn} onClick={handleCloseHistoryBtnClick} altText='히스토리 닫기 버튼'></IconButton>
+      </UpperDiv>
+      <div></div>
+      <div></div>
+    </Wrapper>
+  );
+};
+
+export default HistoryBar;
+
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flex.columnCenter}
+  position: fixed;
+  background-color: ${({ theme }) => theme.color.gray1};
+  width: 100vw;
+  height: 160px;
+  bottom: 0;
+`;
+
+const UpperDiv = styled.div`
+  ${({ theme }) => theme.flex.row};
+  justify-content: space-between;
+  padding: 0 2rem;
+  width: 100%;
+`;
+
+const topBar = styled.div``;

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -1,10 +1,19 @@
 import styled from '@emotion/styled';
 import { whiteCloseBtn } from 'img';
 import { Title } from 'components/atoms';
-import { IconButton, PlayController } from 'components/molecules';
+import { HistoryLog, IconButton, PlayController } from 'components/molecules';
+import HistoryWindow from 'components/molecules/HistoryWindow';
+import { useHistory } from 'react-router';
+import useProjectId from 'hooks/useRoomId';
 
 const HistoryBar: React.FC = () => {
-  const handleCloseHistoryBtnClick = () => {};
+  const history = useHistory();
+  const projectId = useProjectId();
+
+  const handleCloseHistoryBtnClick = () => {
+    history.push(`/mindmap/${projectId}`);
+  };
+  const dummyData = { modifier: { id: 1, icon: whiteCloseBtn, color: 'blue', name: 'lapa' } };
 
   return (
     <Wrapper>
@@ -15,8 +24,8 @@ const HistoryBar: React.FC = () => {
         <PlayController />
         <IconButton imgSrc={whiteCloseBtn} onClick={handleCloseHistoryBtnClick} altText='히스토리 닫기 버튼'></IconButton>
       </UpperDiv>
-      <div></div>
-      <div></div>
+      <HistoryWindow />
+      <HistoryLog modifier={dummyData.modifier} log='테스트용 로그' />
     </Wrapper>
   );
 };
@@ -30,6 +39,7 @@ const Wrapper = styled.div`
   width: 100vw;
   height: 160px;
   bottom: 0;
+  padding: 0 2rem;
 `;
 
 const UpperDiv = styled.div`
@@ -37,6 +47,7 @@ const UpperDiv = styled.div`
   justify-content: space-between;
   padding: 0 2rem;
   width: 100%;
+  height: 45px;
 `;
 
 const topBar = styled.div``;

--- a/client/src/components/organisms/MindmapBtnWrapper/index.tsx
+++ b/client/src/components/organisms/MindmapBtnWrapper/index.tsx
@@ -5,6 +5,7 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { IMindNodes, mindNodesState, selectedNodeState } from 'recoil/mindmap';
 import { getId, idxToLevel, levelToIdx } from 'utils/helpers';
 import { BoxButton } from 'components/atoms';
+import useProjectId from 'hooks/useRoomId';
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.flex.row}
@@ -37,9 +38,10 @@ const MindmapWrapper: React.FC = () => {
   const [selectedNodeId, setSelectedNodeId] = useRecoilState(selectedNodeState);
   const mindNodes = useRecoilValue(mindNodesState);
   const hitory = useHistory();
+  const projectId = useProjectId();
 
   const handleHistoryBtnClick = () => {
-    hitory.push('/history');
+    hitory.push(`/history/${projectId}`);
   };
 
   const handlePlusNodeBtnClick = () => {

--- a/client/src/components/organisms/ProjectCard/index.tsx
+++ b/client/src/components/organisms/ProjectCard/index.tsx
@@ -59,8 +59,8 @@ const ProjectCard: React.FC<IProps> = ({ name, count, creator, onClickShareButto
         </SmallText>
       </StyledTextContainer>
       <StyledIconContainer>
-        <IconButton onClick={onClickShareButton} imgSrc={img.share} />
-        <IconButton onClick={onClickDeleteButton} imgSrc={img.trashcan} />
+        <IconButton onClick={onClickShareButton} imgSrc={img.share} altText='공유하기 버튼' />
+        <IconButton onClick={onClickDeleteButton} imgSrc={img.trashcan} altText='삭제하기 버튼' />
       </StyledIconContainer>
     </StyledProjectCard>
   );

--- a/client/src/components/organisms/index.tsx
+++ b/client/src/components/organisms/index.tsx
@@ -8,3 +8,4 @@ export { default as MindmapBtnWrapper } from 'components/organisms/MindmapBtnWra
 export { default as Mindmap } from 'components/organisms/Mindmap';
 export { default as MindmapTree } from 'components/organisms/MindmapTree';
 export { default as Header } from 'components/organisms/Header';
+export { default as HistoryBar } from 'components/organisms/HistoryBar';

--- a/client/src/hooks/useRoomId/index.tsx
+++ b/client/src/hooks/useRoomId/index.tsx
@@ -1,0 +1,10 @@
+import { useParams } from 'react-router';
+
+interface IParams {
+  projectId: string;
+}
+
+const useProjectId = () => {
+  const params = useParams<IParams>();
+  return params.projectId;
+};

--- a/client/src/hooks/useRoomId/index.tsx
+++ b/client/src/hooks/useRoomId/index.tsx
@@ -8,3 +8,5 @@ const useProjectId = () => {
   const params = useParams<IParams>();
   return params.projectId;
 };
+
+export default useProjectId;

--- a/client/src/img/backwardBtn.svg
+++ b/client/src/img/backwardBtn.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="12" viewBox="0 0 18 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M8.5 12V0L0 6L8.5 12ZM9 6L17.5 12V0L9 6Z" fill="white"/>
+</svg>

--- a/client/src/img/forwardBtn.svg
+++ b/client/src/img/forwardBtn.svg
@@ -1,0 +1,3 @@
+<svg width="18" height="12" viewBox="0 0 18 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 12L8.5 6L0 0V12ZM9 0V12L17.5 6L9 0Z" fill="white"/>
+</svg>

--- a/client/src/img/index.ts
+++ b/client/src/img/index.ts
@@ -7,6 +7,9 @@ import clockPath from './clock.svg';
 import plusCirclePath from './plusCircle.svg';
 import backPath from './back.svg';
 import trashcanPath from './trashcan.svg';
+import backwardBtnPath from './backwardBtn.svg';
+import playBtnPath from './playBtn.svg';
+import forwardBtnPath from './forwardBtn.svg';
 
 export const share: string = sharePath;
 export const logo: string = logoPath;
@@ -17,3 +20,6 @@ export const clock: string = clockPath;
 export const plusCircle: string = plusCirclePath;
 export const back: string = backPath;
 export const trashcan: string = trashcanPath;
+export const backwardBtn: string = backwardBtnPath;
+export const playBtn: string = playBtnPath;
+export const forwardBtn: string = forwardBtnPath;

--- a/client/src/img/index.ts
+++ b/client/src/img/index.ts
@@ -10,6 +10,7 @@ import trashcanPath from './trashcan.svg';
 import backwardBtnPath from './backwardBtn.svg';
 import playBtnPath from './playBtn.svg';
 import forwardBtnPath from './forwardBtn.svg';
+import whiteCloseBtnPath from './whiteCloseBtn.svg';
 
 export const share: string = sharePath;
 export const logo: string = logoPath;
@@ -23,3 +24,4 @@ export const trashcan: string = trashcanPath;
 export const backwardBtn: string = backwardBtnPath;
 export const playBtn: string = playBtnPath;
 export const forwardBtn: string = forwardBtnPath;
+export const whiteCloseBtn: string = whiteCloseBtnPath;

--- a/client/src/img/playBtn.svg
+++ b/client/src/img/playBtn.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="14" viewBox="0 0 11 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0 0V14L11 7L0 0Z" fill="white"/>
+</svg>

--- a/client/src/img/whiteCloseBtn.svg
+++ b/client/src/img/whiteCloseBtn.svg
@@ -1,0 +1,4 @@
+<svg width="19" height="19" viewBox="0 0 19 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.8001 4.6L4.6001 13.8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M4.6001 4.6L13.8001 13.8" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/pages/History/index.tsx
+++ b/client/src/pages/History/index.tsx
@@ -1,0 +1,12 @@
+import { MindmapBackground } from 'components/molecules';
+import { HistoryBar } from 'components/organisms';
+
+const HistoryPage = () => {
+  return (
+    <MindmapBackground>
+      <HistoryBar />
+    </MindmapBackground>
+  );
+};
+
+export default HistoryPage;

--- a/client/src/pages/index.ts
+++ b/client/src/pages/index.ts
@@ -4,3 +4,4 @@ export { default as ProjectPage } from './Project';
 export { default as MindmapPage } from './Mindmap';
 export { default as CalendarPage } from './Calendar';
 export { default as ChartPage } from './Chart';
+export { default as HistoryPage } from './History';


### PR DESCRIPTION
## 📑 제목
하단에 히스토리 창이 토글된다.
## 📎 관련 이슈
- #61 
## ✔️ 셀프 체크리스트
- [x]  히스토리 창 UI 구현
- [x]  히스토리 버튼 클릭시 토글 기능 구현
## 💬 작업 내용
- 히스토리 창 UI 구현
- 히스토리 버튼 클릭 시 히스토리 페이지 이동
- 히스토리 창의 닫기 버튼 클릭 시 마인드맵 페이지 이동
## 🚧 PR 특이 사항
- 몇몇 atom의 props 수정
- useProjectId 커스텀 훅 구현 -> useHistory와 합쳐서 useLink? 리팩토링 예정
## 🕰 실제 소요 시간
2h