### PR TITLE
노드 상세 정보 컴포넌트 입력값 제어

### DIFF
--- a/client/src/components/atoms/Input/index.tsx
+++ b/client/src/components/atoms/Input/index.tsx
@@ -7,7 +7,7 @@ interface IProps extends InputHTMLAttributes<HTMLInputElement> {
 }
 
 const BoxButton: React.FC<IProps> = ({ inputStyle = 'normal', margin = '0', ...props }) => {
-  return <StyledInput inputStyle={inputStyle} margin={margin} {...props} />;
+  return <StyledInput inputStyle={inputStyle} margin={margin} autoComplete={'off'} {...props} />;
 };
 
 export default BoxButton;

--- a/client/src/components/molecules/Label/style.ts
+++ b/client/src/components/molecules/Label/style.ts
@@ -24,6 +24,7 @@ export const Wrapper = styled.div<IStyleProps>`
 
 export const StyledLabel = styled.label<IStyleProps>`
   ${({ theme }) => theme.flex.rowCenter};
+  cursor: pointer;
 `;
 
 const styleOptions: { [key in TStyle]: string } = {

--- a/client/src/components/organisms/NodeDetailWrapper/index.tsx
+++ b/client/src/components/organisms/NodeDetailWrapper/index.tsx
@@ -4,58 +4,130 @@ import { useRecoilState, useRecoilValue } from 'recoil';
 import { selectedNodeState, INode } from 'recoil/node';
 import { priorityListState } from 'recoil/meta-data';
 import { Input } from 'components/atoms';
+import { isISODate, isPositiveNumber } from 'utils/form';
 import Dropdown from 'components/molecules/Dropdown';
+import useToast from 'hooks/useToast';
 
 interface IProps {}
 
 export const NodeDetailWrapper: React.FC<IProps> = () => {
-  const [selectedNode, setSelectedNode] = useRecoilState(selectedNodeState);
   const priorityList = useRecoilValue(priorityListState);
+  const [selectedNode, setSelectedNode] = useRecoilState(selectedNodeState);
+  const { showMessage } = useToast();
 
   const handleCloseButton = () => setSelectedNode(null);
+  const handleFocusAlarm = useCallback((msg: string) => (e: React.FocusEvent<HTMLInputElement>) => showMessage(msg), [showMessage]);
+
   const handleBlurNodeDetail = useCallback(
     (info: keyof INode) => (e: React.FocusEvent<HTMLInputElement>) => {
       if (e.target.value === selectedNode?.[info]) {
         return;
       }
       //! 노드 내용 변경 요청
+      showMessage(`${info} ${e.target.value}로 변경.`);
     },
-    [selectedNode]
+    [selectedNode, showMessage]
   );
+
   const handleChangeNodeDetail = useCallback(
     (info: keyof INode) => (value: string) => {
       if (value === selectedNode?.[info]) {
         return;
       }
       //! 노드 내용 변경 요청
+      showMessage(`${info} ${value}로 변경.`);
     },
-    [selectedNode]
+    [selectedNode, showMessage]
+  );
+
+  const handleBlurExpectedAt = useCallback(
+    ({ target }: React.FocusEvent<HTMLInputElement>) => {
+      if (!target.value) {
+        return;
+      }
+      if (!isISODate(target.value)) {
+        showMessage('YYYY-MM-DD 형식으로 입력하세요.');
+        return;
+      }
+      if (target.value !== selectedNode?.expectedAt) {
+        //! 노드 내용 변경 요청
+        showMessage(`마감 날짜 ${target.value}으로 변경.`);
+        return;
+      }
+    },
+    [selectedNode, showMessage]
+  );
+
+  const handleBlurExpectedTime = useCallback(
+    ({ target }: React.FocusEvent<HTMLInputElement>) => {
+      if (!target.value) {
+        return;
+      }
+      if (!isPositiveNumber(target.value)) {
+        showMessage('숫자만 입력하세요. 단위는 시(hour)입니다.');
+        return;
+      }
+      const newExpectedTime = target.value + '시간';
+      if (newExpectedTime !== selectedNode?.expectedTime) {
+        //! 노드 내용 변경 요청
+        showMessage(`예상 소요 시간 ${newExpectedTime}으로 변경.`);
+        return;
+      }
+    },
+    [selectedNode, showMessage]
   );
 
   return selectedNode === null ? null : (
     <PopupLayout title={selectedNode.backlogId} onClose={handleCloseButton} popupStyle='normal'>
       <PopupItemLayout title={'내용'}>
-        <Input inputStyle='gray' onBlur={handleBlurNodeDetail('content')} defaultValue={selectedNode.content} margin='0.2rem 0 0 0'></Input>
+        <Input defaultValue={selectedNode.content} onBlur={handleBlurNodeDetail('content')} inputStyle='gray' margin='0.2rem 0 0 0'></Input>
       </PopupItemLayout>
       <PopupItemLayout title={'세부사항'}>
         <Label label='스프린트' labelStyle='small' ratio={0.5} htmlFor='sprint'>
-          <Input inputStyle='small' id='sprint' margin='0.1rem 0'></Input>
+          <Dropdown
+            id='sprint'
+            items={['스프린트1', '스프린트2']}
+            placeholder={selectedNode.sprint}
+            onValueChange={handleChangeNodeDetail('sprint')}
+            dropdownStyle='small'
+          />
         </Label>
         <Label label='담당자' labelStyle='small' ratio={0.5} htmlFor='assignee'>
-          <Input inputStyle='small' id='assignee' margin='0.1rem 0'></Input>
+          <Dropdown
+            id='assignee'
+            items={['통키', '파피']}
+            placeholder={selectedNode.assignee}
+            onValueChange={handleChangeNodeDetail('assignee')}
+            dropdownStyle='small'
+          />
         </Label>
-        <Label label='마감 시간' labelStyle='small' ratio={0.5} htmlFor='expectedAt'>
-          <Input inputStyle='small' id='expectedAt' margin='0.1rem 0'></Input>
+        <Label label='마감 날짜' labelStyle='small' ratio={0.5} htmlFor='expectedAt'>
+          <Input
+            id='expectedAt'
+            placeholder={selectedNode.expectedAt}
+            onFocus={handleFocusAlarm('YYYY-MM-DD 형식으로 입력하세요.')}
+            onBlur={handleBlurExpectedAt}
+            inputStyle='small'
+            margin='0.1rem 0'
+          />
         </Label>
         <Label label='예상 소요 시간' labelStyle='small' ratio={0.5} htmlFor='expectedTime'>
-          <Input inputStyle='small' id='expectedTime' margin='0.1rem 0'></Input>
+          <Input
+            id='expectedTime'
+            placeholder={selectedNode.expectedTime}
+            onFocus={handleFocusAlarm('숫자만 입력하세요. 단위는 시(hour)입니다.')}
+            onBlur={handleBlurExpectedTime}
+            inputStyle='small'
+            margin='0.1rem 0'
+          />
         </Label>
-        <Label label='중요도' labelStyle='small' ratio={0.5} htmlFor='priority'>
+        <Label label='중요도' htmlFor='priority' labelStyle='small' ratio={0.5}>
           <Dropdown
-            dropdownStyle='small'
+            id='priority'
             items={priorityList}
-            value={selectedNode.priority}
+            placeholder={selectedNode.priority}
             onValueChange={handleChangeNodeDetail('priority')}
+            dropdownStyle='small'
           />
         </Label>
       </PopupItemLayout>

--- a/client/src/recoil/node/index.ts
+++ b/client/src/recoil/node/index.ts
@@ -8,7 +8,7 @@ export interface INode {
   content: string;
   children: Array<number>;
   label: number[];
-  sprint: number | undefined;
+  sprint: string | undefined;
   assignee: string | undefined;
   createdAt: string;
   expectedAt: string | undefined;
@@ -25,10 +25,10 @@ const sampleNode: INode = {
   content: '화살표 클릭으로 월별로 달력을 이동할 수 있다.',
   children: [10, 11],
   label: [1, 2],
-  sprint: undefined,
+  sprint: '스프린트1',
   assignee: '조성현',
-  createdAt: new Date().toISOString(),
-  expectedAt: new Date().toISOString(),
+  createdAt: '2021-11-10',
+  expectedAt: '2021-12-03',
   closedAt: undefined,
   expectedTime: '1시간',
   priority: '높음',

--- a/client/src/utils/form.ts
+++ b/client/src/utils/form.ts
@@ -1,0 +1,7 @@
+export const isNumber = (input: string) => input !== '' && !isNaN(Number(input));
+
+export const isPositive = (input: string) => Number(input) > 0;
+
+export const isPositiveNumber = (input: string) => isNumber(input) && isPositive(input);
+
+export const isISODate = (input: string) => RegExp(/\d{4}-([0]\d|1[0-2])-([0-2]\d|3[01])/g).test(input);

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     image: 'redis'
     ports:
       - '6379:6379'
-    # volumes:
-    #   - D:/boostcamp_membership/project/redis/6379/data:/data
-    #   - D:/boostcamp_membership/project/redis/6379/conf/redis.conf:/usr/local/etc/redis/redis.conf
+    volumes:
+      #   - D:/boostcamp_membership/project/redis/6379/data:/data
+      - ./redis.conf:/usr/local/etc/redis/redis.conf
     command: redis-server /usr/local/etc/redis/redis.conf
     mem_limit: '500m'


### PR DESCRIPTION
## 📑 제목
노드 상세 정보 컴포넌트 입력값 제어

## 📎 관련 이슈
- #16 

## ✔️ 셀프 체크리스트
- [x] 잘못된 입력시 ui 알림

## 💬 작업 내용
- [x] 노드 상세정보 입력시 검증 로직
- [x]  드롭다운 적용

![image](https://user-images.githubusercontent.com/73219421/141077832-70b33f27-615b-405e-bc26-d0d91186db94.png)


## 🚧 PR 특이 사항
정규표현식으로 간단하게 제어하기로 결정했습니다..

## 🕰 실제 소요 시간
2h
