### PR TITLE
마인드맵 노드 생성, 삭제, 수정

### DIFF
--- a/client/src/components/templates/ProjectCardContainer/socket.ts
+++ b/client/src/components/templates/ProjectCardContainer/socket.ts
@@ -19,16 +19,15 @@ export class SocketManager {
     this.socket.on('left', (id) => {
       console.log('left', id);
     });
-    this.socket.on('event', (data) => {
-      console.log('event', data);
+    this.socket.on('event', (eventLog, dbData) => {
+      console.log('event', eventLog, dbData);
     });
-    const nodeFrom = '';
-    const nodeTo = '';
-    const dataFrom = '';
-    setTimeout(
-      () => this.socket.emit('event', 'ADD_NODE', JSON.stringify({ nodeFrom, nodeTo, dataFrom, dataTo: { content: '123' } })),
-      1000
-    );
+    const eventType = 'DELETE_NODE';
+    const nodeFrom = 20;
+    const nodeTo = null;
+    const dataFrom = { nodeId: 26 };
+    const dataTo = { content: '123345', posX: '1', posY: '2' };
+    setTimeout(() => this.socket.emit('event', eventType, JSON.stringify({ nodeFrom, nodeTo, dataFrom, dataTo })), 1000);
 
     SocketManager.instance = this;
   }

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: process.env.REACT_APP_SERVER,
+  baseURL: process.env.REACT_APP_SERVER + 'api',
   withCredentials: true,
 });
 

--- a/server/src/database/entities/Mindmap.ts
+++ b/server/src/database/entities/Mindmap.ts
@@ -6,7 +6,7 @@ export class Mindmap {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @ManyToOne(() => Project, (project) => project.mindmap, { cascade: true })
+  @ManyToOne(() => Project, (project) => project.mindmap, { onDelete: 'CASCADE' })
   project: Project;
 
   @Column({ default: null })

--- a/server/src/database/entities/Project.ts
+++ b/server/src/database/entities/Project.ts
@@ -21,6 +21,6 @@ export class Project {
   @JoinTable()
   users: User[];
 
-  @OneToMany(() => Mindmap, (mindmap) => mindmap.project)
+  @OneToMany(() => Mindmap, (mindmap) => mindmap.project, { cascade: true })
   mindmap: Mindmap[];
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -38,7 +38,7 @@ app.use(
   })
 );
 
-app.use('/', router);
+app.use('/api', router);
 
 app.use(function (err, req, res, next) {
   if (err.status) {

--- a/server/src/services/mindmap.ts
+++ b/server/src/services/mindmap.ts
@@ -17,14 +17,41 @@ export const getMindMap = async (projectId: string) => {
     .where('project.id = :projectId', { projectId })
     .getMany();
 };
-export const createNode = async (projectId: string, nodeInfo: INode) => {
+export const createNode = async (projectId: string, parendId: number | null, nodeInfo: INode) => {
   const project = await findOneProject(projectId);
-  const newNode = { ...nodeInfo, project };
-  return getRepository(Mindmap).save(newNode);
+  const newNode = await getRepository(Mindmap).save({ children: JSON.stringify([]), ...nodeInfo, project });
+  if (parendId) {
+    addNodeToParent(parendId, newNode.id);
+  }
+  return newNode.id;
 };
-export const deleteNode = async (nodeId: number) => {
-  return getRepository(Mindmap).createQueryBuilder().delete().where({ id: nodeId }).execute();
+export const deleteNode = async (parendId: number, nodeId: number) => {
+  deleteNodeFromParent(parendId, nodeId);
+  deleteNodeAndChildren(nodeId);
+  return;
 };
 export const updateNode = async (nodeId: number, newData: INode) => {
   return getRepository(Mindmap).createQueryBuilder().update().set(newData).where('id = :nodeId', { nodeId }).execute();
+};
+const addNodeToParent = async (parendId: number | null, newNodeId: number) => {
+  const parent = await findOneNode(parendId);
+  const children = [...JSON.parse(parent.children), newNodeId];
+  updateNode(parendId, { children: JSON.stringify(children) });
+};
+const deleteNodeFromParent = async (parendId: number | null, nodeId: number) => {
+  const parent = await findOneNode(parendId);
+  const children = JSON.parse(parent.children).filter((childId: number) => childId !== nodeId);
+  updateNode(parendId, { children: JSON.stringify(children) });
+};
+const deleteNodeAndChildren = async (nodeId: number) => {
+  const node = await findOneNode(nodeId);
+  const children = JSON.parse(node.children) as number[];
+  if (children.length > 0) {
+    children.forEach((child) => deleteNodeAndChildren(child));
+  }
+  getRepository(Mindmap).createQueryBuilder().delete().where({ id: nodeId }).execute();
+};
+const findOneNode = (nodeId: number) => {
+  const id = nodeId.toString(10);
+  return getRepository(Mindmap).findOne({ where: { id } });
 };

--- a/server/src/services/mindmap.ts
+++ b/server/src/services/mindmap.ts
@@ -17,31 +17,31 @@ export const getMindMap = async (projectId: string) => {
     .where('project.id = :projectId', { projectId })
     .getMany();
 };
-export const createNode = async (projectId: string, parendId: number | null, nodeInfo: INode) => {
+export const createNode = async (projectId: string, parentId: number | null, nodeInfo: INode) => {
   const project = await findOneProject(projectId);
   const newNode = await getRepository(Mindmap).save({ children: JSON.stringify([]), ...nodeInfo, project });
-  if (parendId) {
-    addNodeToParent(parendId, newNode.id);
+  if (parentId) {
+    addNodeToParent(parentId, newNode.id);
   }
   return newNode.id;
 };
-export const deleteNode = async (parendId: number, nodeId: number) => {
-  deleteNodeFromParent(parendId, nodeId);
+export const deleteNode = async (parentId: number, nodeId: number) => {
+  deleteNodeFromParent(parentId, nodeId);
   deleteNodeAndChildren(nodeId);
   return;
 };
 export const updateNode = async (nodeId: number, newData: INode) => {
   return getRepository(Mindmap).createQueryBuilder().update().set(newData).where('id = :nodeId', { nodeId }).execute();
 };
-const addNodeToParent = async (parendId: number | null, newNodeId: number) => {
-  const parent = await findOneNode(parendId);
+const addNodeToParent = async (parentId: number | null, newNodeId: number) => {
+  const parent = await findOneNode(parentId);
   const children = [...JSON.parse(parent.children), newNodeId];
-  updateNode(parendId, { children: JSON.stringify(children) });
+  updateNode(parentId, { children: JSON.stringify(children) });
 };
-const deleteNodeFromParent = async (parendId: number | null, nodeId: number) => {
-  const parent = await findOneNode(parendId);
+const deleteNodeFromParent = async (parentId: number | null, nodeId: number) => {
+  const parent = await findOneNode(parentId);
   const children = JSON.parse(parent.children).filter((childId: number) => childId !== nodeId);
-  updateNode(parendId, { children: JSON.stringify(children) });
+  updateNode(parentId, { children: JSON.stringify(children) });
 };
 const deleteNodeAndChildren = async (nodeId: number) => {
   const node = await findOneNode(nodeId);

--- a/server/src/services/project.ts
+++ b/server/src/services/project.ts
@@ -16,7 +16,7 @@ export const getUserProject = async (userId: string) => {
 export const createProject = async (name: string, creator: string) => {
   const user = await findOneUser(creator);
   const newProject = await getRepository(Project).save({ name, creator: user, users: [user] });
-  createNode(newProject.id, { content: name, posX: '0', posY: '0' });
+  createNode(newProject.id, null, { content: name, posX: '0', posY: '0', children: JSON.stringify([]) });
   return newProject;
 };
 

--- a/server/src/utils/eventConverter.ts
+++ b/server/src/utils/eventConverter.ts
@@ -1,8 +1,6 @@
-enum eventType {
-  'ADD_NODE',
-  'DELETE_NODE',
-  'UPDATE_NODE',
-}
+import { createNode, updateNode, deleteNode } from '../services/mindmap';
+
+type eventType = 'ADD_NODE' | 'DELETE_NODE' | 'UPDATE_NODE_CONTENT';
 enum eventArgs {
   'type' = 1,
   'project' = 3,
@@ -10,7 +8,26 @@ enum eventArgs {
   'data' = 7,
 }
 
+const eventFunction = (): Record<eventType, any> => {
+  return {
+    ADD_NODE: (data: string, project: string) => {
+      const { nodeFrom, dataTo } = JSON.parse(data);
+      return createNode(project, nodeFrom, dataTo);
+    },
+    DELETE_NODE: (data: string) => {
+      const { nodeFrom, dataFrom } = JSON.parse(data);
+      deleteNode(nodeFrom, dataFrom['nodeId']);
+      return;
+    },
+    UPDATE_NODE_CONTENT: (data: string) => {
+      const { nodeFrom, dataTo } = JSON.parse(data);
+      updateNode(nodeFrom, dataTo);
+      return;
+    },
+  };
+};
+
 export const convertEvent = (args: string[]) => {
-  const [type, project, user, data] = Object.keys(eventArgs).map((str) => args[str]);
-  console.log(type, project, user, JSON.parse(data));
+  const [type, project, user, data] = ['type', 'project', 'user', 'data'].map((str) => args[eventArgs[str]]);
+  return eventFunction()[type](data, project, user);
 };

--- a/server/src/utils/redis.ts
+++ b/server/src/utils/redis.ts
@@ -1,16 +1,17 @@
 import redis from 'redis';
 
 export const xread = (stream: string, id: string, callback: (str) => void) => {
-  const redisClient = redis.createClient();
-  redisClient.xread('BLOCK', 0, 'STREAMS', stream, id, (err, str) => {
+  const xreadClient = redis.createClient();
+  xreadClient.xread('BLOCK', 0, 'STREAMS', stream, id, (err, str) => {
     if (err) throw err;
     callback(str);
+    xreadClient.quit();
   });
 };
 
+const xaddClient = redis.createClient();
 export const xadd = ({ stream, args }: { stream: string; args: string[] }) => {
-  const redisClient = redis.createClient();
-  redisClient.xadd(stream, '*', ...args, (err, stream) => {
+  xaddClient.xadd(stream, '*', ...args, (err, stream) => {
     if (err) throw err;
   });
 };

--- a/server/src/utils/socket.ts
+++ b/server/src/utils/socket.ts
@@ -64,8 +64,7 @@ const socketIO = (server, origin) => {
 
     socket.on('leave', (projectId) => {
       socket.leave(projectId);
-      userInRooms[projectId] = userInRooms[projectId].filter((user) => user !== id);
-      socket.to(projectId).emit('left', id);
+      socket.disconnect();
     });
 
     socket.on('event', (type, data) => {

--- a/server/src/utils/socket.ts
+++ b/server/src/utils/socket.ts
@@ -41,7 +41,7 @@ const socketIO = (server, origin) => {
 
     const handleNewEvent = (data: Record<number, object>) => {
       data[0][1].forEach((element) => {
-        socket.to(projectId).emit('event', element[1]);
+        io.in(projectId).emit('event', element[1]);
         convertEvent(element[1]);
       });
     };

--- a/server/src/utils/socket.ts
+++ b/server/src/utils/socket.ts
@@ -47,7 +47,9 @@ const socketIO = (server, origin) => {
     };
 
     socket.join(projectId);
+
     if (!userInRooms.hasOwnProperty(projectId)) {
+      xread(projectId, '$', handleNewEvent);
       userInRooms[projectId] = [id];
     } else {
       userInRooms[projectId].push(id);

--- a/server/src/utils/socket.ts
+++ b/server/src/utils/socket.ts
@@ -39,11 +39,10 @@ const socketIO = (server, origin) => {
     const { id } = socket.decoded;
     const projectId = socket.handshake.query.projectId as string;
 
-    const handleNewEvent = (data: Record<number, object>) => {
-      data[0][1].forEach((element) => {
-        io.in(projectId).emit('event', element[1]);
-        convertEvent(element[1]);
-      });
+    const handleNewEvent = async (data: Record<number, object>) => {
+      const eventData = data[0][1][0][1];
+      const dbData = await convertEvent(eventData);
+      io.in(projectId).emit('event', eventData, dbData);
     };
 
     socket.join(projectId);


### PR DESCRIPTION
## 📑 제목
마인드맵 노드 생성, 삭제, 수정
## 📎 관련 이슈
- #59 
## ✔️ 셀프 체크리스트
- [x] mysql 연동
- [x] event 해석
## 💬 작업 내용
- 이벤트컨버터에서 해석해서 mysql db 업데이트
## 🚧 PR 특이 사항
- event type
  - ADD_NODE: nodeFrom - 부모노드 id, dataTo - 생성 시에는 content, posX, posY 값 필요. 생성된 노드의 id 반환
  - DELETE_NODE: nodeFrom - 부모 노드 id, dataFrom - nodeId 값 필요. 해당 노드와 그 자식노드까지 모두 삭제
  - UPDATE_NODE_CONTENT: nodeFrom - 노드id, dataTo - content 값 필요 
## 🕰 실제 소요 시간
4h