### PR TITLE
히스토리 활성화시 마인드맵 비활성화, 히스토리 내역 아이콘/#62#63

### DIFF
--- a/client/src/components/atoms/Background/index.tsx
+++ b/client/src/components/atoms/Background/index.tsx
@@ -2,16 +2,17 @@ import React from 'react';
 import { BackgroundDiv, TSize, TColor } from './style';
 
 interface IProps {
-  bgSize?: TSize;
+  bgSize: TSize;
   bgColor?: TColor;
+  zIndex?: number;
   children?: React.ReactNode;
   id?: string;
   className?: string;
 }
 
-const Background: React.FC<IProps> = ({ className, bgColor, bgSize, children, id }) => {
+const Background: React.FC<IProps> = ({ className, bgColor, bgSize, children, id, zIndex }) => {
   return (
-    <BackgroundDiv id={id} className={className} bgColor={bgColor} bgSize={bgSize}>
+    <BackgroundDiv id={id} className={className} bgColor={bgColor} bgSize={bgSize} zIndex={zIndex}>
       {children}
     </BackgroundDiv>
   );

--- a/client/src/components/atoms/Background/index.tsx
+++ b/client/src/components/atoms/Background/index.tsx
@@ -1,26 +1,19 @@
 import React from 'react';
-import styled from '@emotion/styled';
+import { BackgroundDiv, TSize, TColor } from './style';
 
 interface IProps {
-  width?: string;
-  height?: string;
+  bgSize?: TSize;
+  bgColor?: TColor;
   children?: React.ReactNode;
   id?: string;
   className?: string;
 }
 
-const WhiteBackground = styled.div<IProps>`
-  position: relative;
-  background-color: ${(props) => props.theme.color.bgWhite};
-  width: ${(props) => props.width};
-  height: ${(props) => props.height};
-`;
-
-const Background: React.FC<IProps> = ({ className, width = '100vw', height = '100vh', children, id }) => {
+const Background: React.FC<IProps> = ({ className, bgColor, bgSize, children, id }) => {
   return (
-    <WhiteBackground id={id} width={width} height={height} className={className}>
+    <BackgroundDiv id={id} className={className} bgColor={bgColor} bgSize={bgSize}>
       {children}
-    </WhiteBackground>
+    </BackgroundDiv>
   );
 };
 

--- a/client/src/components/atoms/Background/style.tsx
+++ b/client/src/components/atoms/Background/style.tsx
@@ -5,22 +5,25 @@ export type TSize = 'full' | 'over';
 
 interface IStyleProps {
   bgColor?: TColor;
-  bgSize?: TSize;
+  bgSize: TSize;
   position?: string;
+  zIndex?: number;
 }
 
 export const BackgroundDiv = styled.div<IStyleProps>`
-  position: ${({ position }) => position ?? 'relative'};
+  ${({ bgSize }) => bgSizeOptions[bgSize]}
+  position: ${({ position }) => position ?? 'absolute'};
   background-color: ${({ theme, bgColor }) => (bgColor ? theme.color[bgColor] : theme.color.bgWhite)};
+  z-index: ${({ zIndex }) => zIndex ?? 0};
 `;
 
 const bgSizeOptions: { [key in TSize]: string } = {
   full: `
-    width: 100%
-    heigth: 100%
+    width: 100%;
+    height: 100%;
     `,
   over: `
-    width: 5000px
-    hegit: 5000px
+    width: 5000px;
+    height: 5000px;
     `,
 };

--- a/client/src/components/atoms/Background/style.tsx
+++ b/client/src/components/atoms/Background/style.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+export type TColor = 'white' | 'bgWhite' | 'gray5';
+export type TSize = 'full' | 'over';
+
+interface IStyleProps {
+  bgColor?: TColor;
+  bgSize?: TSize;
+  position?: string;
+}
+
+export const BackgroundDiv = styled.div<IStyleProps>`
+  position: ${({ position }) => position ?? 'relative'};
+  background-color: ${({ theme, bgColor }) => (bgColor ? theme.color[bgColor] : theme.color.bgWhite)};
+`;
+
+const bgSizeOptions: { [key in TSize]: string } = {
+  full: `
+    width: 100%
+    heigth: 100%
+    `,
+  over: `
+    width: 5000px
+    hegit: 5000px
+    `,
+};

--- a/client/src/components/atoms/index.tsx
+++ b/client/src/components/atoms/index.tsx
@@ -7,3 +7,5 @@ export { default as TransparentButton } from 'components/atoms/TransparentButton
 export { default as ModalBox } from 'components/atoms/ModalBox';
 export { default as ModalOverlay } from 'components/atoms/ModalOverlay';
 export { default as SmallText } from 'components/atoms/SmallText';
+export { default as Background } from 'components/atoms/Background';
+export { default as Node } from 'components/atoms/Node';

--- a/client/src/components/atoms/svgCurve/index.tsx
+++ b/client/src/components/atoms/svgCurve/index.tsx
@@ -1,6 +1,0 @@
-const svgCurve = () => {
-  //from to curve
-  return <svg></svg>;
-};
-
-export default svgCurve;

--- a/client/src/components/molecules/HistoryLog/index.tsx
+++ b/client/src/components/molecules/HistoryLog/index.tsx
@@ -8,18 +8,27 @@ const Wrapper = styled.div`
   width: 100%;
 `;
 
-interface IPros {
+export interface IDescription {
   modifier: IUser;
-  log: string;
+  type: 'ADD_NODE' | 'DELETE_NODE' | 'UPDATE_NODE_POSITION' | 'UPDATE_NODE_CONTENT';
+  content: string;
 }
 
-const HistoryLog: React.FC<IPros> = ({ modifier, log }) => {
+interface IProps {
+  description: IDescription | null;
+}
+
+const HistoryLog: React.FC<IProps> = ({ description }) => {
   return (
     <Wrapper>
-      <Profile user={modifier} />
-      <Title titleStyle='xlarge' color='white' margin='0 0 0 0.5rem' lineHeight={2}>
-        {log}
-      </Title>
+      {description ? (
+        <>
+          <Profile user={description.modifier} />
+          <Title titleStyle='xlarge' color='white' margin='0 0 0 0.5rem' lineHeight={2}>
+            {description.type}
+          </Title>
+        </>
+      ) : null}
     </Wrapper>
   );
 };

--- a/client/src/components/molecules/HistoryWindow/index.tsx
+++ b/client/src/components/molecules/HistoryWindow/index.tsx
@@ -1,11 +1,16 @@
 import { IconWrapper, Wrapper } from './style';
 import { closeIcon } from 'img';
 import { IconImg } from 'components/atoms';
-import { useEffect, useRef } from 'react';
+import { MouseEvent, MouseEventHandler, useEffect, useRef } from 'react';
+import { IHistoryData } from 'components/organisms/HistoryBar';
 
-const HistoryWindow = () => {
+interface IProps {
+  onClick: (historyData: IHistoryData, idx: number) => (event: MouseEvent) => void;
+  histories?: IHistoryData[];
+}
+
+const HistoryWindow: React.FC<IProps> = ({ onClick, histories }) => {
   const scrollRef = useRef(null);
-  const data = dummy;
 
   useEffect(() => {
     if (!scrollRef.current) return;
@@ -14,55 +19,16 @@ const HistoryWindow = () => {
 
   return (
     <Wrapper>
-      {data.map(({ icon, color }, idx) => (
-        <IconWrapper key={idx} color={color}>
-          <IconImg imgSrc={icon} altText={`히스토리 ${idx + 1}`} />
-        </IconWrapper>
-      ))}
+      {histories
+        ? histories.map((historyData, idx) => (
+            <IconWrapper key={idx} color={historyData.modifier.color} onClick={onClick(historyData, idx)}>
+              <IconImg imgSrc={historyData.modifier.icon} altText={`히스토리 ${idx + 1}`} />
+            </IconWrapper>
+          ))
+        : null}
       <div ref={scrollRef} id='scrollEnd' />
     </Wrapper>
   );
 };
 
 export default HistoryWindow;
-
-const dummy = [
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'skyblue' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-  { icon: closeIcon, color: 'red' },
-];

--- a/client/src/components/molecules/HistoryWindow/index.tsx
+++ b/client/src/components/molecules/HistoryWindow/index.tsx
@@ -1,14 +1,68 @@
-import styled from '@emotion/styled';
-
-const Wrapper = styled.div`
-  background-color: ${({ theme }) => theme.color.bgWhite};
-  width: 100%;
-  margin: 0 2rem;
-  height: 70px;
-`;
+import { IconWrapper, Wrapper } from './style';
+import { closeIcon } from 'img';
+import { IconImg } from 'components/atoms';
+import { useEffect, useRef } from 'react';
 
 const HistoryWindow = () => {
-  return <Wrapper></Wrapper>;
+  const scrollRef = useRef(null);
+  const data = dummy;
+
+  useEffect(() => {
+    if (!scrollRef.current) return;
+    (scrollRef.current as HTMLElement).scrollIntoView();
+  }, [scrollRef.current]);
+
+  return (
+    <Wrapper>
+      {data.map(({ icon, color }, idx) => (
+        <IconWrapper key={idx} color={color}>
+          <IconImg imgSrc={icon} altText={`히스토리 ${idx + 1}`} />
+        </IconWrapper>
+      ))}
+      <div ref={scrollRef} id='scrollEnd' />
+    </Wrapper>
+  );
 };
 
 export default HistoryWindow;
+
+const dummy = [
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'skyblue' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+  { icon: closeIcon, color: 'red' },
+];

--- a/client/src/components/molecules/HistoryWindow/style.tsx
+++ b/client/src/components/molecules/HistoryWindow/style.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  background-color: ${({ theme }) => theme.color.bgWhite};
+  width: 100%;
+  height: 70px;
+  ${({ theme }) => theme.flex.row}
+  overflow: scroll;
+  gap: 1rem;
+  align-items: center;
+`;
+
+export const IconWrapper = styled.div`
+  background-color: ${({ color }) => color};
+  width: 45px;
+  height: 45px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/client/src/components/molecules/MindmapBackground/index.tsx
+++ b/client/src/components/molecules/MindmapBackground/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react';
 import Background from 'components/atoms/Background';
-import { getCenterCoord, MINDMAP_BG_SIZE, numToPx } from 'utils/helpers';
+import { getCenterCoord } from 'utils/helpers';
 
 interface ICoord {
   clientX: number;
@@ -74,12 +74,7 @@ const MindmapBackground: React.FC<IProps> = ({ className, children }) => {
   }, [addListeners, removeListeners]);
 
   return (
-    <Background
-      id={'mindmapBackground'}
-      width={numToPx(MINDMAP_BG_SIZE.WIDTH)}
-      height={numToPx(MINDMAP_BG_SIZE.HEIGHT)}
-      className={className}
-    >
+    <Background id={'mindmapBackground'} className={className} bgSize='over' bgColor='bgWhite'>
       {children}
     </Background>
   );

--- a/client/src/components/molecules/MindmapBackground/index.tsx
+++ b/client/src/components/molecules/MindmapBackground/index.tsx
@@ -1,80 +1,16 @@
-import { useCallback, useEffect, useRef } from 'react';
-import Background from 'components/atoms/Background';
-import { getCenterCoord } from 'utils/helpers';
-
-interface ICoord {
-  clientX: number;
-  clientY: number;
-}
+import { Background } from 'components/atoms';
+import useDragBackground from 'hooks/useDragBackground';
 
 interface IProps {
   children?: React.ReactNode;
   className?: string;
 }
 
-const [centerX, centerY] = getCenterCoord(window.innerWidth, window.innerHeight);
-
 const MindmapBackground: React.FC<IProps> = ({ className, children }) => {
-  const lastCoord = useRef<ICoord | null>(null);
-  const draggable = useRef(false);
-  const timer = useRef<NodeJS.Timeout | null>(null);
-
-  const toggleDraggable = () => (draggable.current = !draggable.current);
-
-  const handleWindowMouseDown = useCallback(({ clientX, clientY, target }: MouseEvent) => {
-    if ((target as HTMLElement).id !== 'mindmapBackground') return;
-    toggleDraggable();
-    lastCoord.current = { clientX, clientY };
-  }, []);
-
-  const handleWindowMouseUp = useCallback(({ target }: MouseEvent) => {
-    if ((target as HTMLElement).id !== 'mindmapBackground') return;
-    toggleDraggable();
-    lastCoord.current = null;
-  }, []);
-
-  const handleWindowMouseMove = useCallback(({ clientX, clientY }: MouseEvent) => {
-    if (!draggable.current || !lastCoord.current) return;
-    if (timer.current) return;
-
-    timer.current = setTimeout(
-      (clientX, clientY) => {
-        timer.current = null;
-
-        if (!lastCoord.current) return;
-        const diffX = lastCoord.current.clientX - clientX;
-        const diffY = lastCoord.current.clientY - clientY;
-
-        window.scrollBy(diffX, diffY);
-        lastCoord.current = { clientX, clientY };
-      },
-      20,
-      clientX,
-      clientY
-    );
-  }, []);
-
-  const addListeners = useCallback(() => {
-    window.addEventListener('mousedown', handleWindowMouseDown);
-    window.addEventListener('mousemove', handleWindowMouseMove);
-    window.addEventListener('mouseup', handleWindowMouseUp);
-  }, [handleWindowMouseDown, handleWindowMouseMove, handleWindowMouseUp]);
-
-  const removeListeners = useCallback(() => {
-    window.removeEventListener('mousedown', handleWindowMouseDown);
-    window.removeEventListener('mousemove', handleWindowMouseMove);
-    window.removeEventListener('mouseup', handleWindowMouseUp);
-  }, [handleWindowMouseDown, handleWindowMouseMove, handleWindowMouseUp]);
-
-  useEffect(() => {
-    window.scrollTo(centerX, centerY);
-    addListeners();
-
-    return removeListeners;
-  }, [addListeners, removeListeners]);
+  useDragBackground();
 
   return (
-    <Background id={'mindmapBackground'} className={className} bgSize='over' bgColor='bgWhite'>
+    <Background className={className} bgSize='over' bgColor='bgWhite'>
       {children}
     </Background>
   );

--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -1,6 +1,6 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
-import Node from 'components/atoms/Node';
+import { Node } from 'components/atoms';
 import { TCoord, TRect, getCurrentCoord, getGap, getType, calcRect } from 'utils/helpers';
 import { Path } from '../../molecules';
 import { getNextMapState, IMindmapData, mindmapState } from 'recoil/mindmap';

--- a/client/src/components/molecules/index.tsx
+++ b/client/src/components/molecules/index.tsx
@@ -10,3 +10,4 @@ export { default as PlayController } from 'components/molecules/PlayController';
 export { default as HistoryLog } from 'components/molecules/HistoryLog';
 export { default as Profile } from 'components/molecules/Profile';
 export { default as Spinner } from 'components/molecules/Spinner';
+export { default as HistoryWindow } from 'components/molecules/HistoryWindow';

--- a/client/src/components/organisms/HistoryBackground/index.tsx
+++ b/client/src/components/organisms/HistoryBackground/index.tsx
@@ -1,0 +1,21 @@
+import { Background } from 'components/atoms';
+import useDragBackground from 'hooks/useDragBackground';
+import { useRecoilValue } from 'recoil';
+import { mindmapState } from 'recoil/mindmap';
+import { Mindmap } from '..';
+
+const HistoryBackground = () => {
+  useDragBackground();
+  const data = useRecoilValue(mindmapState);
+
+  return (
+    <>
+      <Background bgSize='over' bgColor='gray5' className='background' />
+      <Background bgSize='over' zIndex={-10}>
+        <Mindmap mindmapData={data} />
+      </Background>
+    </>
+  );
+};
+
+export default HistoryBackground;

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -1,14 +1,35 @@
+import { MouseEvent, useState } from 'react';
 import { whiteCloseBtn } from 'img';
-import { Title } from 'components/atoms';
-import { HistoryLog, IconButton, PlayController } from 'components/molecules';
-import HistoryWindow from 'components/molecules/HistoryWindow';
-import { Wrapper, UpperDiv } from './style';
 import useLinkClick from 'hooks/useLinkClick';
+import { Wrapper, UpperDiv } from './style';
+import { Title } from 'components/atoms';
+import { HistoryLog, IconButton, PlayController, HistoryWindow } from 'components/molecules';
+import { IDescription } from 'components/molecules/HistoryLog';
+
+export interface IHistoryData extends IDescription {
+  from: number;
+  target: number;
+  to?: number;
+  posX?: number;
+  posY?: number;
+}
+
+const getUser = (id: number) => ({ id: id, icon: whiteCloseBtn, color: 'blue', name: 'lapa' });
+const dummyData = [
+  { modifier: getUser(1), type: 'UPDATE_NODE_POSITION', from: 7, to: 9, target: 11, content: 'TASK' } as const,
+  { modifier: getUser(1), type: 'ADD_NODE', from: 8, target: 19, content: 'TASK' } as const,
+  { modifier: getUser(1), type: 'ADD_NODE', from: 4, target: 18, content: 'TASK' } as const,
+];
 
 const HistoryBar: React.FC = () => {
   const handleCloseHistoryBtnClick = useLinkClick('mindmap');
+  const [currentDescription, setCurrentDescription] = useState<IDescription | null>(null);
+  const [lastDe];
 
-  const dummyData = { modifier: { id: 1, icon: whiteCloseBtn, color: 'blue', name: 'lapa' } };
+  const handleHistoryClick = (historyData: IHistoryData, idx: number) => (event: MouseEvent) => {
+    const { modifier, type, content, from, to, target, posX, posY } = historyData;
+    setCurrentDescription({ modifier, type, content });
+  };
 
   return (
     <Wrapper>
@@ -19,10 +40,19 @@ const HistoryBar: React.FC = () => {
         <PlayController />
         <IconButton imgSrc={whiteCloseBtn} onClick={handleCloseHistoryBtnClick} altText='히스토리 닫기 버튼'></IconButton>
       </UpperDiv>
-      <HistoryWindow />
-      <HistoryLog modifier={dummyData.modifier} log='테스트용 로그' />
+      <HistoryWindow onClick={handleHistoryClick} histories={dummyData} />
+      <HistoryLog description={currentDescription} />
     </Wrapper>
   );
 };
 
 export default HistoryBar;
+
+const restoreHistory = (historyData: IHistoryData) => {};
+
+const restoreFunctions = {
+  ADD_NODE: ({ from, content, target }: IHistoryData) => {},
+  DELETE_NODE: () => {},
+  UPDATE_NODE_POSITION: ({ from, to, target, content }: IHistoryData) => {},
+  UPDATE_NODE_CONTENT: () => {},
+};

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -24,7 +24,6 @@ const dummyData = [
 const HistoryBar: React.FC = () => {
   const handleCloseHistoryBtnClick = useLinkClick('mindmap');
   const [currentDescription, setCurrentDescription] = useState<IDescription | null>(null);
-  const [lastDe];
 
   const handleHistoryClick = (historyData: IHistoryData, idx: number) => (event: MouseEvent) => {
     const { modifier, type, content, from, to, target, posX, posY } = historyData;

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -14,11 +14,11 @@ export interface IHistoryData extends IDescription {
   posY?: number;
 }
 
-const getUser = (id: number) => ({ id: id, icon: whiteCloseBtn, color: 'blue', name: 'lapa' });
+const getUser = (id: string) => ({ id: id, icon: whiteCloseBtn, color: 'blue', name: 'lapa' });
 const dummyData = [
-  { modifier: getUser(1), type: 'UPDATE_NODE_POSITION', from: 7, to: 9, target: 11, content: 'TASK' } as const,
-  { modifier: getUser(1), type: 'ADD_NODE', from: 8, target: 19, content: 'TASK' } as const,
-  { modifier: getUser(1), type: 'ADD_NODE', from: 4, target: 18, content: 'TASK' } as const,
+  { modifier: getUser('lapa'), type: 'UPDATE_NODE_POSITION', from: 7, to: 9, target: 11, content: 'TASK' } as const,
+  { modifier: getUser('lapa'), type: 'ADD_NODE', from: 8, target: 19, content: 'TASK' } as const,
+  { modifier: getUser('lapa'), type: 'ADD_NODE', from: 4, target: 18, content: 'TASK' } as const,
 ];
 
 const HistoryBar: React.FC = () => {

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -1,37 +1,14 @@
-import styled from '@emotion/styled';
 import { whiteCloseBtn } from 'img';
 import { Title } from 'components/atoms';
 import { HistoryLog, IconButton, PlayController } from 'components/molecules';
 import HistoryWindow from 'components/molecules/HistoryWindow';
-import { useHistory } from 'react-router';
-import useProjectId from 'hooks/useRoomId';
-
-const Wrapper = styled.div`
-  ${({ theme }) => theme.flex.columnCenter}
-  position: fixed;
-  background-color: ${({ theme }) => theme.color.gray1};
-  width: 100vw;
-  height: 160px;
-  bottom: 0;
-  padding: 0 2rem;
-`;
-
-const UpperDiv = styled.div`
-  ${({ theme }) => theme.flex.row};
-  justify-content: space-between;
-  padding: 0 2rem;
-  width: 100%;
-  height: 45px;
-`;
+import { Wrapper, UpperDiv } from './style';
+import useLinkClick from 'hooks/useLinkClick';
 
 const HistoryBar: React.FC = () => {
-  const history = useHistory();
-  const projectId = useProjectId();
+  const handleCloseHistoryBtnClick = useLinkClick('mindmap');
 
-  const handleCloseHistoryBtnClick = () => {
-    history.push(`/mindmap/${projectId}`);
-  };
-  const dummyData = { modifier: { id: '123', icon: whiteCloseBtn, color: 'blue', name: 'lapa' } };
+  const dummyData = { modifier: { id: 1, icon: whiteCloseBtn, color: 'blue', name: 'lapa' } };
 
   return (
     <Wrapper>

--- a/client/src/components/organisms/HistoryBar/style.tsx
+++ b/client/src/components/organisms/HistoryBar/style.tsx
@@ -1,0 +1,19 @@
+import styled from '@emotion/styled';
+
+export const Wrapper = styled.div`
+  ${({ theme }) => theme.flex.columnCenter}
+  position: fixed;
+  background-color: ${({ theme }) => theme.color.gray1};
+  width: 100vw;
+  height: 160px;
+  bottom: 0;
+  padding: 0 2rem;
+`;
+
+export const UpperDiv = styled.div`
+  ${({ theme }) => theme.flex.row};
+  justify-content: space-between;
+  padding: 0 2rem;
+  width: 100%;
+  height: 45px;
+`;

--- a/client/src/components/organisms/index.tsx
+++ b/client/src/components/organisms/index.tsx
@@ -10,3 +10,4 @@ export { default as MindmapTree } from 'components/organisms/MindmapTree';
 export { default as Header } from 'components/organisms/Header';
 export { default as HistoryBar } from 'components/organisms/HistoryBar';
 export { default as UserList } from 'components/organisms/UserList';
+export { default as HistoryBackground } from 'components/organisms/HistoryBackground';

--- a/client/src/components/templates/MindmapTemplate/index.tsx
+++ b/client/src/components/templates/MindmapTemplate/index.tsx
@@ -6,7 +6,7 @@ import { Mindmap, MindmapBtnWrapper } from 'components/organisms';
 const MindmapTemplate: React.FC = () => {
   const mindmapData = useRecoilValue(mindmapState);
   return (
-    <MindmapBackground className='mindmap-area'>
+    <MindmapBackground className='mindmap-area background'>
       <Mindmap mindmapData={mindmapData} />
       <MindmapBtnWrapper />
     </MindmapBackground>

--- a/client/src/hooks/useDragBackground/index.tsx
+++ b/client/src/hooks/useDragBackground/index.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { getCenterCoord } from 'utils/helpers';
+
+interface ICoord {
+  clientX: number;
+  clientY: number;
+}
+
+const useDragBackground = () => {
+  const lastCoord = useRef<ICoord | null>(null);
+  const draggable = useRef(false);
+  const timer = useRef<NodeJS.Timeout | null>(null);
+
+  const [centerX, centerY] = getCenterCoord(window.innerWidth, window.innerHeight);
+
+  const toggleDraggable = () => (draggable.current = !draggable.current);
+
+  const handleWindowMouseDown = useCallback(({ clientX, clientY, target }: MouseEvent) => {
+    console.log(target);
+    console.log((target as HTMLElement).className.includes('background'));
+    if (!(target as HTMLElement).className.includes('background')) return;
+    toggleDraggable();
+    lastCoord.current = { clientX, clientY };
+  }, []);
+
+  const handleWindowMouseUp = useCallback(({ target }: MouseEvent) => {
+    if (!(target as HTMLElement).className.includes('background')) return;
+    toggleDraggable();
+    lastCoord.current = null;
+  }, []);
+
+  const handleWindowMouseMove = useCallback(({ clientX, clientY }: MouseEvent) => {
+    if (!draggable.current || !lastCoord.current) return;
+    if (timer.current) return;
+
+    timer.current = setTimeout(
+      (clientX, clientY) => {
+        timer.current = null;
+
+        if (!lastCoord.current) return;
+        const diffX = lastCoord.current.clientX - clientX;
+        const diffY = lastCoord.current.clientY - clientY;
+
+        window.scrollBy(diffX, diffY);
+        lastCoord.current = { clientX, clientY };
+      },
+      20,
+      clientX,
+      clientY
+    );
+  }, []);
+
+  const addListeners = useCallback(() => {
+    window.addEventListener('mousedown', handleWindowMouseDown);
+    window.addEventListener('mousemove', handleWindowMouseMove);
+    window.addEventListener('mouseup', handleWindowMouseUp);
+  }, [handleWindowMouseDown, handleWindowMouseMove, handleWindowMouseUp]);
+
+  const removeListeners = useCallback(() => {
+    window.removeEventListener('mousedown', handleWindowMouseDown);
+    window.removeEventListener('mousemove', handleWindowMouseMove);
+    window.removeEventListener('mouseup', handleWindowMouseUp);
+  }, [handleWindowMouseDown, handleWindowMouseMove, handleWindowMouseUp]);
+
+  useEffect(() => {
+    window.scrollTo(centerX, centerY);
+    addListeners();
+
+    return removeListeners;
+  }, [addListeners, removeListeners]);
+};
+
+export default useDragBackground;

--- a/client/src/hooks/useLinkClick/index.tsx
+++ b/client/src/hooks/useLinkClick/index.tsx
@@ -1,0 +1,17 @@
+import useProjectId from 'hooks/useRoomId';
+import { useHistory } from 'react-router';
+
+type TPath = 'project' | 'mindmap' | 'history' | 'kanban' | 'calendar' | 'chart';
+
+const useLinkClick = (path: TPath) => {
+  const history = useHistory();
+  const projectId = useProjectId();
+
+  const handleLinkClick = () => {
+    history.push(`/${path}/${projectId}`);
+  };
+
+  return handleLinkClick;
+};
+
+export default useLinkClick;

--- a/client/src/pages/History/index.tsx
+++ b/client/src/pages/History/index.tsx
@@ -1,8 +1,10 @@
-import { Background } from 'components/atoms';
-import { MindmapBackground } from 'components/molecules';
-import { HistoryBackground, HistoryBar, Mindmap } from 'components/organisms';
+import { HistoryBackground, HistoryBar } from 'components/organisms';
+
+const getHistoryData = () => {};
 
 const HistoryPage = () => {
+  const historyData = getHistoryData();
+
   return (
     <>
       <HistoryBackground />

--- a/client/src/pages/History/index.tsx
+++ b/client/src/pages/History/index.tsx
@@ -1,11 +1,13 @@
+import { Background } from 'components/atoms';
 import { MindmapBackground } from 'components/molecules';
-import { HistoryBar } from 'components/organisms';
+import { HistoryBackground, HistoryBar, Mindmap } from 'components/organisms';
 
 const HistoryPage = () => {
   return (
-    <MindmapBackground>
+    <>
+      <HistoryBackground />
       <HistoryBar />
-    </MindmapBackground>
+    </>
   );
 };
 

--- a/client/src/styles/common.ts
+++ b/client/src/styles/common.ts
@@ -31,7 +31,7 @@ const color: { [key in TColor]: string } = {
   gray2: '#BBBBBB',
   gray3: '#D7D7D7',
   gray4: '#EEEEEE',
-  gray5: '#BBBBBBBB',
+  gray5: '#BBBBBB99',
 };
 
 const calcRem = (px: number) => `${px / 16}rem`;

--- a/client/src/styles/common.ts
+++ b/client/src/styles/common.ts
@@ -10,6 +10,7 @@ export type TColor =
   | 'gray2'
   | 'gray3'
   | 'gray4'
+  | 'gray5'
   | 'yellow'
   | 'mint';
 export type TFontSize = 'small' | 'normal' | 'large' | 'xlarge' | 'xxlarge' | 'xxxlarge' | 'title';
@@ -30,6 +31,7 @@ const color: { [key in TColor]: string } = {
   gray2: '#BBBBBB',
   gray3: '#D7D7D7',
   gray4: '#EEEEEE',
+  gray5: '#BBBBBBBB',
 };
 
 const calcRem = (px: number) => `${px / 16}rem`;


### PR DESCRIPTION
## 📑 제목
히스토리 창이 활성화 되면, 마인드맵 부분은 회색으로 흐려진다.
히스토리 각각은 프로필 아이콘으로 표시되어 구분한다.
## 📎 관련 이슈
- #62 
- #63
## ✔️ 셀프 체크리스트
- [x] 히스토리 창이 활성화 됐을 시 기존의 마인드 맵 화면이 회색으로 흐려짐 구현
- [x] 마인드 맵이 보이는 화면은 인터렉션 불가
- [x] 히스토리 내역 UI 구현
## 💬 작업 내용
- Background Atom 리팩토링 후 재사용
- 마인드맵 배경 회색으로 흐려지고 인터렉션 불가 구현
- 히스토리 내역 목록 아이콘으로 표시, 가로로 나열
## 🚧 PR 특이 사항
- 히스토리 스크롤을 오른쪽 끝에서 시작하도록 변경하는 중
- 마우스로 드래그해 스크롤하는 useDragBackground를 범용적으로 리팩토링 필요
- 히스토리 변경로직 구현 중
## 🕰 실제 소요 시간
5h