### PR TITLE
recoil cache 문제 해결

### DIFF
--- a/client/src/hooks/useUserReceiver/index.ts
+++ b/client/src/hooks/useUserReceiver/index.ts
@@ -34,7 +34,7 @@ const useUserReceiver = () => {
         break;
       case 'NEW':
         showMessage(`${data} 님이 새로 참여하셨습니다.`);
-        forceUserListReload((reload) => !reload);
+        forceUserListReload(new Date().toISOString());
         break;
       case 'INIT':
         const connectedUser: Record<string, boolean> = {};

--- a/client/src/recoil/user-list/index.ts
+++ b/client/src/recoil/user-list/index.ts
@@ -13,9 +13,9 @@ export const connectedUserState = atom<Record<string, boolean>>({
   default: {},
 });
 
-export const forceReloadUserList = atom<boolean>({
+export const forceReloadUserList = atom<string>({
   key: 'reload',
-  default: false,
+  default: '',
 });
 
 export const queryUserListState = selector({


### PR DESCRIPTION
## 📑 제목
recoil cache 문제 해결
## 📎 관련 이슈
- #57
## ✔️ 셀프 체크리스트
- [x] 유저 리스트 갱신
## 💬 작업 내용
- 유저 리스트를 recoil에서 selector get으로 비동기로 받아오고, 새로운 유저가 들어오면 forceReloadState를 통해 다시 api 요청을 보내도록 했는데 true false를 하니까 cache되어 유저리스트가 제대로 되지 않았다.
## 🚧 PR 특이 사항

## 🕰 실제 소요 시간
0.5h