### PR TITLE
임시 노드에 내용 입력 시 실제 노드 생성 #17

### DIFF
--- a/client/src/components/atoms/Node/index.tsx
+++ b/client/src/components/atoms/Node/index.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled';
 import { Levels, levelToIdx } from 'utils/helpers';
 
-interface IProps {
+export interface INodeProps {
   level: Levels;
   isSelected: boolean;
 }
 
-const Node = styled.p<IProps>`
+const Node = styled.div<INodeProps>`
   background-color: ${({ theme, level }) => theme.nodeBgColors[levelToIdx(level)]};
   color: ${({ theme, level }) => theme.nodeColors[levelToIdx(level)]};
   border-radius: 0.5rem;

--- a/client/src/components/molecules/TempNode/index.tsx
+++ b/client/src/components/molecules/TempNode/index.tsx
@@ -1,6 +1,6 @@
 import { Node, Input } from 'components/atoms';
 import { INodeProps } from 'components/atoms/Node';
-import React, { FormEvent, MutableRefObject, RefObject } from 'react';
+import React, { FormEvent } from 'react';
 
 interface IProps extends INodeProps {
   onBlur: ({ currentTarget }: FormEvent<HTMLInputElement>) => void;

--- a/client/src/components/molecules/TempNode/index.tsx
+++ b/client/src/components/molecules/TempNode/index.tsx
@@ -1,0 +1,22 @@
+import { Node, Input } from 'components/atoms';
+import { INodeProps } from 'components/atoms/Node';
+import React, { FormEvent, MutableRefObject, RefObject } from 'react';
+
+interface IProps extends INodeProps {
+  onBlur: ({ currentTarget }: FormEvent<HTMLInputElement>) => void;
+  onKeyPress: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  id: string;
+  refProp: React.MutableRefObject<HTMLDivElement | null>;
+}
+
+const TempNode: React.FC<IProps> = (props) => {
+  const { onBlur, onKeyPress, level, isSelected, id, refProp } = props;
+
+  return (
+    <Node ref={refProp} id={id} level={level} isSelected={isSelected}>
+      <Input inputStyle='small' autoFocus onBlur={onBlur} onKeyPress={onKeyPress} />
+    </Node>
+  );
+};
+
+export default TempNode;

--- a/client/src/components/molecules/index.tsx
+++ b/client/src/components/molecules/index.tsx
@@ -11,3 +11,4 @@ export { default as HistoryLog } from 'components/molecules/HistoryLog';
 export { default as Profile } from 'components/molecules/Profile';
 export { default as Spinner } from 'components/molecules/Spinner';
 export { default as HistoryWindow } from 'components/molecules/HistoryWindow';
+export { default as TempNode } from 'components/molecules/TempNode';

--- a/client/src/components/organisms/Mindmap/index.tsx
+++ b/client/src/components/organisms/Mindmap/index.tsx
@@ -103,7 +103,7 @@ const changeNodeParent = ({ curNodes, nextNodes, nodeInfos, moveNode, draggedEle
     dataTo: changeNodeIds.map((nodeId) => nextNodes.get(nodeId!)),
   };
 
-  moveNode(payload);
+  // moveNode(payload);
 };
 
 const getNodeInfo = (nodeInfos: INodeInfos, nodeId: number, mindNodes: IMindNodes) => {

--- a/client/src/hooks/useHistoryEmitter/index.ts
+++ b/client/src/hooks/useHistoryEmitter/index.ts
@@ -1,5 +1,6 @@
 import useToast from 'hooks/useToast';
 import { IData } from 'recoil/history';
+import { fillPayload } from 'utils/helpers';
 
 export interface IHistoryEmitter {
   (props: IHistoryEmitterProps): void;
@@ -30,23 +31,34 @@ const useHistoryEmitter = () => {
       showMessage('서버와의 연결이 불안정합니다');
       return;
     }
+
+    payload = fillPayload(payload);
+
     window.socket.emit('event', type, JSON.stringify(payload));
   };
 
   const addNode = ({ nodeFrom, dataTo }: IData) => historyEmitter({ type: EventType.ADD_NODE, payload: { nodeFrom, dataTo } });
+
   const moveNode = ({ nodeFrom, nodeTo, dataFrom, dataTo }: IData) =>
     historyEmitter({ type: EventType.MOVE_NODE, payload: { nodeFrom, nodeTo, dataFrom, dataTo } });
+
   const deleteNode = ({ nodeFrom, dataFrom }: IData) => historyEmitter({ type: EventType.DELETE_NODE, payload: { nodeFrom, dataFrom } });
+
   const changeContent = ({ nodeFrom, dataFrom, dataTo }: IData) =>
     historyEmitter({ type: EventType.CHANGE_CONTENT, payload: { nodeFrom, dataFrom, dataTo } });
+
   const changeSprint = ({ nodeFrom, dataFrom, dataTo }: IData) =>
     historyEmitter({ type: EventType.CHANGE_SPRINT, payload: { nodeFrom, dataFrom, dataTo } });
+
   const changeAssignee = ({ nodeFrom, dataFrom, dataTo }: IData) =>
     historyEmitter({ type: EventType.CHANGE_ASSIGNEE, payload: { nodeFrom, dataFrom, dataTo } });
+
   const changeExpectedAt = ({ nodeFrom, dataFrom, dataTo }: IData) =>
     historyEmitter({ type: EventType.CHANGE_EXPECTED_AT, payload: { nodeFrom, dataFrom, dataTo } });
+
   const changeExpectedTime = ({ nodeFrom, dataFrom, dataTo }: IData) =>
     historyEmitter({ type: EventType.CHANGE_EXPECTED_TIME, payload: { nodeFrom, dataFrom, dataTo } });
+
   const changePriority = ({ nodeFrom, dataFrom, dataTo }: IData) =>
     historyEmitter({ type: EventType.CHANGE_PRIORITY, payload: { nodeFrom, dataFrom, dataTo } });
 

--- a/client/src/hooks/useHistoryReceiver/index.ts
+++ b/client/src/hooks/useHistoryReceiver/index.ts
@@ -1,7 +1,8 @@
 import { EventType } from 'hooks/useHistoryEmitter';
 import { SetterOrUpdater } from 'recoil';
-import { IHistories, IHistory } from 'recoil/history';
+import { AddData, IData, IHistories, IHistory, TDataTypes } from 'recoil/history';
 import { getNextMapState, IMindmapData, IMindNode } from 'recoil/mindmap';
+import { idxToLevel, levelToIdx } from 'utils/helpers';
 
 export interface IProps {
   mindmap: IMindmapData;
@@ -10,7 +11,7 @@ export interface IProps {
 }
 
 export interface IHistoryReceiver {
-  (props: IHistory): void;
+  (history: IHistory): void;
 }
 
 export interface IHistoryHandlerProps {
@@ -20,33 +21,58 @@ export interface IHistoryHandlerProps {
   isForward: boolean;
 }
 
+interface IAddNodeProps {
+  mapState: IMindmapData;
+  parentId: number;
+  id: number;
+  data: IData;
+  mindmapSetter: SetterOrUpdater<IMindmapData>;
+}
+
 export const historyHandler = ({ mindmap, setMindmap, history, isForward }: IHistoryHandlerProps) => {
   const {
     type,
-    data: { nodeFrom, dataFrom, dataTo },
+    data: { nodeTo, nodeFrom, dataFrom, dataTo },
   } = history;
   const nextMapState = getNextMapState(mindmap);
   const setChangeNodes = (mapState: IMindmapData, nodes: IMindNode[]) => {
     nodes.forEach((node) => mapState.mindNodes.set(node.nodeId, { ...node, children: node.children }));
   };
+
+  const addNode = ({ data, mapState, parentId, id, mindmapSetter }: IAddNodeProps) => {
+    const { content, children } = data.dataTo as AddData;
+    const parsedChildren = JSON.parse(children);
+    const parent = mapState.mindNodes.get(parentId);
+    const level = idxToLevel(levelToIdx(parent!.level) + 1);
+    const node = { content, level, nodeId: id, children: parsedChildren };
+    const newChildren = [...parent!.children.filter((childId) => childId !== -1), id];
+    const newParent = { ...parent!, children: newChildren };
+    nextMapState.mindNodes.set(id, node);
+    nextMapState.mindNodes.set(parentId, newParent);
+    nextMapState.mindNodes.delete(-1);
+    mindmapSetter(nextMapState);
+  };
+
   switch (type) {
     case EventType.ADD_NODE:
+      addNode({ mapState: nextMapState, parentId: nodeFrom!, id: history.id, data: history.data, mindmapSetter: setMindmap });
+      break;
     case EventType.CHANGE_CONTENT:
     case EventType.CHANGE_SPRINT:
     case EventType.CHANGE_ASSIGNEE:
     case EventType.CHANGE_EXPECTED_AT:
     case EventType.CHANGE_EXPECTED_TIME:
     case EventType.CHANGE_PRIORITY:
-      if (isForward) nextMapState.mindNodes.set(nodeFrom!, dataTo as IMindNode);
-      else nextMapState.mindNodes.set(nodeFrom!, dataFrom as IMindNode);
+      // if (isForward) nextMapState.mindNodes.set(nodeFrom!, dataTo as IMindNode);
+      // else nextMapState.mindNodes.set(nodeFrom!, dataFrom as IMindNode);
       break;
     case EventType.MOVE_NODE:
-      if (isForward) setChangeNodes(nextMapState, dataTo as IMindNode[]);
-      else setChangeNodes(nextMapState, dataFrom as IMindNode[]);
+      // if (isForward) setChangeNodes(nextMapState, dataTo as IMindNode[]);
+      // else setChangeNodes(nextMapState, dataFrom as IMindNode[]);
       break;
     case EventType.DELETE_NODE:
       if (isForward) nextMapState.mindNodes.delete(nodeFrom!);
-      else nextMapState.mindNodes.set(nodeFrom!, dataFrom as IMindNode);
+      // else nextMapState.mindNodes.set(nodeFrom!, dataFrom as IMindNode);
       break;
     default:
       break;

--- a/client/src/hooks/useSocketSetup/index.ts
+++ b/client/src/hooks/useSocketSetup/index.ts
@@ -39,8 +39,8 @@ const initSocket = ({ projectId, setSocket, historyReceiver, userReceiver }: IIn
   socket.on('left', (userId: string) => {
     userReceiver({ data: userId, type: 'LEFT' });
   });
-  socket.on('event', (data) => {
-    const history = getParsedHistory(data);
+  socket.on('event', (data, id) => {
+    const history = getParsedHistory(data, id);
     console.log('event', history);
     historyReceiver(history);
   });

--- a/client/src/recoil/history/index.ts
+++ b/client/src/recoil/history/index.ts
@@ -6,10 +6,10 @@ export interface IHistories {
 }
 
 export interface IData {
-  nodeFrom?: number;
-  nodeTo?: number;
-  dataFrom?: unknown;
-  dataTo?: unknown;
+  nodeFrom?: number | null;
+  nodeTo?: number | null;
+  dataFrom?: TDataTypes | null;
+  dataTo?: TDataTypes | null;
 }
 
 export interface IHistory {
@@ -17,23 +17,63 @@ export interface IHistory {
   projectId: string;
   user: string;
   data: IData;
+  id: number;
 }
+
+export interface AddData {
+  content: string;
+  children: string;
+}
+
+interface DeleteData {
+  id: number;
+  content: string;
+  index: number;
+  status: string;
+  posX: number;
+  posY: number;
+  assignee: string;
+  priority: string;
+}
+
+interface MoveData {
+  posX: number;
+  posY: number;
+}
+
+interface UpdateParentData {
+  id: number;
+}
+
+interface UpdateChildrenData {
+  parentId: number;
+  children: number[];
+}
+
+interface UpdateInfoData {
+  changed: { assignee: string };
+}
+
+export type TDataTypes = AddData | DeleteData | MoveData | UpdateParentData | UpdateChildrenData | UpdateInfoData;
 
 export const historyState = atom<IHistories>({
   key: 'historyAtom',
   default: { histories: [] },
 });
 
-export const getParsedHistory = (data: string[]): IHistory => {
+export const getParsedHistory = (data: string[], id?: number): IHistory => {
   const stringJson =
-    data.reduce((acc: string, v: string, i: number) => {
-      if (!(i % 2)) {
-        acc += `"${v}":`;
-      } else {
-        acc += v[0] === '{' ? `${v}` : `"${v}"`;
-        if (i !== data.length - 1) acc += ', ';
-      }
-      return acc;
-    }, '{') + '}';
+    data.reduce(
+      (acc: string, v: string, i: number) => {
+        if (!(i % 2)) {
+          acc += `"${v}":`;
+        } else {
+          acc += v[0] === '{' ? `${v}` : `"${v}"`;
+          if (i !== data.length - 1) acc += ', ';
+        }
+        return acc;
+      },
+      id ? `{"id": ${id},` : '{'
+    ) + '}';
   return JSON.parse(stringJson);
 };

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { IData } from 'recoil/history';
+
 interface ICoord {
   x: number;
   y: number;
@@ -110,7 +112,10 @@ const getNewNode = (id: number, level: Levels, content: string) => ({
   comment: [],
 });
 
+const fillPayload = (payload: IData): IData => ({ nodeFrom: null, nodeTo: null, dataFrom: null, dataTo: null, ...payload });
+
 export {
+  fillPayload,
   getNewNode,
   calcRect,
   getType,

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -114,7 +114,10 @@ const getNewNode = (id: number, level: Levels, content: string) => ({
 
 const fillPayload = (payload: IData): IData => ({ nodeFrom: null, nodeTo: null, dataFrom: null, dataTo: null, ...payload });
 
+const getChildLevel = (level: Levels): Levels => idxToLevel(levelToIdx(level) + 1);
+
 export {
+  getChildLevel,
   fillPayload,
   getNewNode,
   calcRect,

--- a/server/src/database/entities/Mindmap.ts
+++ b/server/src/database/entities/Mindmap.ts
@@ -4,26 +4,26 @@ import { Project } from './Project';
 @Entity()
 export class Mindmap {
   @PrimaryGeneratedColumn()
-    id: number;
+  id: number;
 
   @ManyToOne(() => Project, (project) => project.mindmap, { onDelete: 'CASCADE' })
-    project: Project;
+  project: Project;
 
   @Column({ default: null })
-    label: string;
+  label: string;
 
   @Column({ default: null })
-    children: string;
+  children: string;
 
   @Column()
-    content: string;
+  content: string;
 
-  @Column()
-    posX: string;
+  @Column({ default: null })
+  posX: string;
 
-  @Column()
-    posY: string;
+  @Column({ default: null })
+  posY: string;
 
   @CreateDateColumn()
-    createdAt: Date;
+  createdAt: Date;
 }


### PR DESCRIPTION
## 📑 제목
임시 노드에 내용 입력 시 실제 노드 생성
## 📎 관련 이슈
- #17 
## ✔️ 셀프 체크리스트
- [x] 임시로 노드가 생성되면 노드 내 내용 입력 인풋에 포커스 된다.
- [x] 내용을 입력하고 엔터를 누르거나 바깥 영역을 클릭하면 노드가 생성되고, 서버에 알려준다.
- [x] 내용이 없는 상태로 바깥 영역을 클릭하면 임시 노드가 삭제된다.
## 💬 작업 내용
- 임시노드의 input에 content가 있는 채로 focusout, enter 입력 시 socket으로 생성 데이터 전송
- 소켓에서 생성 데이터를 받아 새 노드 추가
- TempNode molecule 분리
- 관련 util함수 생성
## 🚧 PR 특이 사항
- 이벤트 데이터 스키마 변경으로 관련 코드 주석처리
- 소켓 생성 시 mapState를 전달하기 때문에 새로 노드 추가 시 처음의 마인드맵에서 추가되는 버그 존재
- 버그 해결 후 리팩토링 필요
## 🕰 실제 소요 시간
- 8h