### PR TITLE
히스토리 DB 저장

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -16,7 +16,9 @@
     }
   },
   "rules": {
-    "no-use-before-define": ["error", { "functions": false, "classes": true, "variables": true }],
-    "@typescript-eslint/no-use-before-define": ["error", { "functions": false, "classes": true, "variables": true, "typedefs": true }]
+    "no-use-before-define": "off",
+    "@typescript-eslint/no-use-before-define": ["error", { "functions": false, "classes": true, "variables": true, "typedefs": true }],
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }]
   }
 }

--- a/server/src/database/entities/Comment.ts
+++ b/server/src/database/entities/Comment.ts
@@ -1,10 +1,10 @@
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
 import { Mindmap } from './Mindmap';
 
 @Entity()
 export class Comment {
-  @PrimaryColumn()
-  id: string;
+  @PrimaryGeneratedColumn()
+  id: number;
 
   @Column()
   comment: string;

--- a/server/src/database/entities/Comment.ts
+++ b/server/src/database/entities/Comment.ts
@@ -1,0 +1,14 @@
+import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Mindmap } from './Mindmap';
+
+@Entity()
+export class Comment {
+  @PrimaryColumn()
+  id: string;
+
+  @Column()
+  comment: string;
+
+  @ManyToOne(() => Mindmap, (node) => node.comment, { onDelete: 'CASCADE' })
+  node: Mindmap;
+}

--- a/server/src/database/entities/Label.ts
+++ b/server/src/database/entities/Label.ts
@@ -1,7 +1,13 @@
-import { Entity, PrimaryColumn } from 'typeorm';
+import { Entity, PrimaryColumn, Column } from 'typeorm';
 
 @Entity()
 export class Label {
   @PrimaryColumn()
+  id: string;
+
+  @Column()
   name: string;
+
+  @Column()
+  color: string;
 }

--- a/server/src/database/entities/Label.ts
+++ b/server/src/database/entities/Label.ts
@@ -1,10 +1,10 @@
-import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
 import { Project } from './Project';
 
 @Entity()
 export class Label {
-  @PrimaryColumn()
-  id: string;
+  @PrimaryGeneratedColumn()
+  id: number;
 
   @Column()
   name: string;

--- a/server/src/database/entities/Label.ts
+++ b/server/src/database/entities/Label.ts
@@ -1,4 +1,5 @@
-import { Entity, PrimaryColumn, Column } from 'typeorm';
+import { Entity, PrimaryColumn, Column, ManyToOne } from 'typeorm';
+import { Project } from './Project';
 
 @Entity()
 export class Label {
@@ -10,4 +11,7 @@ export class Label {
 
   @Column()
   color: string;
+
+  @ManyToOne(() => Project, (project) => project.labels, { onDelete: 'CASCADE' })
+  project: Project;
 }

--- a/server/src/database/entities/Mindmap.ts
+++ b/server/src/database/entities/Mindmap.ts
@@ -9,10 +9,7 @@ export class Mindmap {
   @ManyToOne(() => Project, (project) => project.mindmap, { onDelete: 'CASCADE' })
   project: Project;
 
-  @Column({ default: null })
-  label: string;
-
-  @Column({ default: null })
+  @Column({ default: '[]' })
   children: string;
 
   @Column()

--- a/server/src/database/entities/Mindmap.ts
+++ b/server/src/database/entities/Mindmap.ts
@@ -1,4 +1,5 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, ManyToOne } from 'typeorm';
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, ManyToOne, OneToMany } from 'typeorm';
+import { Comment } from './Comment';
 import { Project } from './Project';
 
 @Entity()
@@ -23,4 +24,7 @@ export class Mindmap {
 
   @CreateDateColumn()
   createdAt: Date;
+
+  @OneToMany(() => Comment, (comment) => comment.node, { cascade: true })
+  comment: Comment[];
 }

--- a/server/src/database/entities/Project.ts
+++ b/server/src/database/entities/Project.ts
@@ -29,7 +29,7 @@ export class Project {
   @OneToMany(() => Sprint, (sprint) => sprint.project, { cascade: true })
   sprints: Sprint[];
 
-  @ManyToMany(() => Label, (label) => label.name, { cascade: true })
+  @ManyToMany(() => Label, (label) => label.id, { cascade: true })
   @JoinTable()
   labels: Label[];
 }

--- a/server/src/database/entities/Project.ts
+++ b/server/src/database/entities/Project.ts
@@ -29,7 +29,6 @@ export class Project {
   @OneToMany(() => Sprint, (sprint) => sprint.project, { cascade: true })
   sprints: Sprint[];
 
-  @ManyToMany(() => Label, (label) => label.id, { cascade: true })
-  @JoinTable()
+  @OneToMany(() => Label, (label) => label.project, { cascade: true })
   labels: Label[];
 }

--- a/server/src/database/entities/Sprint.ts
+++ b/server/src/database/entities/Sprint.ts
@@ -5,7 +5,7 @@ import { Task } from './Task';
 @Entity()
 export class Sprint {
   @PrimaryGeneratedColumn()
-  id: string;
+  id: number;
 
   @Column()
   name: string;

--- a/server/src/database/entities/Sprint.ts
+++ b/server/src/database/entities/Sprint.ts
@@ -11,6 +11,9 @@ export class Sprint {
   name: string;
 
   @Column()
+  color: string;
+
+  @Column()
   startDate: string;
 
   @Column()

--- a/server/src/database/entities/Sprint.ts
+++ b/server/src/database/entities/Sprint.ts
@@ -1,5 +1,6 @@
-import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { Project } from './Project';
+import { Task } from './Task';
 
 @Entity()
 export class Sprint {
@@ -17,4 +18,7 @@ export class Sprint {
 
   @ManyToOne(() => Project, (project) => project.sprints, { onDelete: 'CASCADE' })
   project: Project;
+
+  @OneToMany(() => Task, (task) => task.sprint, { onDelete: 'CASCADE' })
+  tasks: Task[];
 }

--- a/server/src/database/entities/Task.ts
+++ b/server/src/database/entities/Task.ts
@@ -1,20 +1,13 @@
-import { Entity, Column, OneToOne, JoinColumn } from 'typeorm';
+import { Entity, Column, OneToOne, ManyToMany, JoinColumn, JoinTable } from 'typeorm';
 import { Mindmap } from './Mindmap';
+import { Label } from './Label';
+import { Sprint } from './Sprint';
 
 @Entity()
 export class Task {
   @OneToOne(() => Mindmap, { primary: true })
   @JoinColumn({ name: 'nodeId' })
   nodeId: Mindmap;
-
-  @Column()
-  sprint: string;
-
-  @Column()
-  label: string;
-
-  @Column()
-  comment: string;
 
   @Column()
   priority: string;
@@ -30,4 +23,12 @@ export class Task {
 
   @Column()
   finishedTime: string;
+
+  @ManyToMany(() => Sprint, (sprints) => sprints.id, { cascade: true })
+  @JoinTable()
+  sprints: Sprint[];
+
+  @ManyToMany(() => Label, (labels) => labels.id, { cascade: true })
+  @JoinTable()
+  labels: Label[];
 }

--- a/server/src/database/entities/Task.ts
+++ b/server/src/database/entities/Task.ts
@@ -16,8 +16,8 @@ export class Task {
   @ManyToOne(() => User, (assignee) => assignee.tasks, { cascade: true })
   assignee: User;
 
-  @Column({ type: 'datetime', nullable: true })
-  dueDate: Date;
+  @Column({ nullable: true })
+  dueDate: string;
 
   @Column({ nullable: true })
   estimatedTime: string;

--- a/server/src/database/entities/Task.ts
+++ b/server/src/database/entities/Task.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, OneToOne, ManyToMany, JoinColumn, JoinTable } from 'typeorm';
+import { Entity, Column, OneToOne, ManyToMany, JoinColumn, JoinTable, ManyToOne } from 'typeorm';
 import { Mindmap } from './Mindmap';
 import { Label } from './Label';
 import { Sprint } from './Sprint';
@@ -24,9 +24,8 @@ export class Task {
   @Column()
   finishedTime: string;
 
-  @ManyToMany(() => Sprint, (sprints) => sprints.id, { cascade: true })
-  @JoinTable()
-  sprints: Sprint[];
+  @ManyToOne(() => Sprint, (sprints) => sprints.id, { cascade: true })
+  sprint: Sprint;
 
   @ManyToMany(() => Label, (labels) => labels.id, { cascade: true })
   @JoinTable()

--- a/server/src/database/entities/Task.ts
+++ b/server/src/database/entities/Task.ts
@@ -10,19 +10,19 @@ export class Task {
   @JoinColumn({ name: 'nodeId' })
   nodeId: Mindmap;
 
-  @Column()
+  @Column({ nullable: true })
   priority: string;
 
   @ManyToOne(() => User, (assignee) => assignee.tasks, { cascade: true })
   assignee: User;
 
-  @Column({ type: 'datetime' })
+  @Column({ type: 'datetime', nullable: true })
   dueDate: Date;
 
-  @Column()
+  @Column({ nullable: true })
   estimatedTime: string;
 
-  @Column()
+  @Column({ nullable: true })
   finishedTime: string;
 
   @ManyToOne(() => Sprint, (sprints) => sprints.id, { cascade: true })

--- a/server/src/database/entities/Task.ts
+++ b/server/src/database/entities/Task.ts
@@ -5,23 +5,29 @@ import { Mindmap } from './Mindmap';
 export class Task {
   @OneToOne(() => Mindmap, { primary: true })
   @JoinColumn({ name: 'nodeId' })
-    nodeId: Mindmap;
+  nodeId: Mindmap;
 
   @Column()
-    sprint: string;
+  sprint: string;
 
   @Column()
-    priority: string;
+  label: string;
 
   @Column()
-    inCharge: string;
+  comment: string;
+
+  @Column()
+  priority: string;
+
+  @Column()
+  assignee: string;
 
   @Column({ type: 'datetime' })
-    dueDate: Date;
+  dueDate: Date;
 
   @Column()
-    estimatedTime: string;
+  estimatedTime: string;
 
   @Column()
-    finishedTime: string;
+  finishedTime: string;
 }

--- a/server/src/database/entities/Task.ts
+++ b/server/src/database/entities/Task.ts
@@ -2,6 +2,7 @@ import { Entity, Column, OneToOne, ManyToMany, JoinColumn, JoinTable, ManyToOne 
 import { Mindmap } from './Mindmap';
 import { Label } from './Label';
 import { Sprint } from './Sprint';
+import { User } from './User';
 
 @Entity()
 export class Task {
@@ -12,8 +13,8 @@ export class Task {
   @Column()
   priority: string;
 
-  @Column()
-  assignee: string;
+  @ManyToOne(() => User, (assignee) => assignee.tasks, { cascade: true })
+  assignee: User;
 
   @Column({ type: 'datetime' })
   dueDate: Date;

--- a/server/src/database/entities/User.ts
+++ b/server/src/database/entities/User.ts
@@ -1,20 +1,24 @@
 import { Entity, Column, PrimaryColumn, OneToMany } from 'typeorm';
 import { Project } from './Project';
+import { Task } from './Task';
 
 @Entity()
 export class User {
   @PrimaryColumn()
-    id: string;
+  id: string;
 
   @Column()
-    name: string;
+  name: string;
 
   @Column()
-    color: string;
+  color: string;
 
   @Column()
-    icon: string;
+  icon: string;
 
   @OneToMany(() => Project, (project) => project.creator)
-    projects: Project[];
+  projects: Project[];
+
+  @OneToMany(() => Task, (tasks) => tasks.assignee)
+  tasks: Task[];
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,6 @@
 import 'reflect-metadata';
-import express from 'express';
+import express, { Error, Request, Response, Next } from 'express';
+
 import bodyParser from 'body-parser';
 import cookieParser from 'cookie-parser';
 import morgan from 'morgan';
@@ -35,12 +36,12 @@ app.use(
     credentials: true,
     maxAge: 3600,
     optionsSuccessStatus: 204,
-  }),
+  })
 );
 
 app.use('/api', router);
 
-app.use(function (err, req, res) {
+app.use(function (err: Error, req: Request, res: Response, next: Next) {
   if (err.status) {
     return res.status(err.status).json({ msg: err.message });
   }

--- a/server/src/services/comment.ts
+++ b/server/src/services/comment.ts
@@ -1,0 +1,16 @@
+import { getRepository } from 'typeorm';
+import { Comment } from '../database/entities/Comment';
+import { findOneNode } from './mindmap';
+import { TAddComment } from '../utils/event-type';
+
+export const findOneComment = async (id: string) => {
+  return getRepository(Comment).findOne({ where: { id } });
+};
+export const createComment = async ({ nodeId, comment }: TAddComment) => {
+  const node = await findOneNode(nodeId);
+  const newComment = await getRepository(Comment).save({ comment, node });
+  return newComment.id;
+};
+export const deleteComment = async (commentId: number) => {
+  return getRepository(Comment).createQueryBuilder().delete().where({ id: commentId }).execute();
+};

--- a/server/src/services/label.ts
+++ b/server/src/services/label.ts
@@ -1,0 +1,18 @@
+import { getRepository } from 'typeorm';
+import { findOneProject } from './project';
+import { TAddLabel } from '../utils/event-type';
+import { Label } from '../database/entities/Label';
+import { Color } from '../database/entities/Color';
+
+export const findOneLabel = async (id: string) => {
+  return getRepository(Label).findOne({ where: { id } });
+};
+export const createLabel = async (projectId: string, labelInfo: TAddLabel) => {
+  const project = await findOneProject(projectId);
+  const color = await getRepository(Color).createQueryBuilder().orderBy('RAND()').getOne();
+  const newLabel = await getRepository(Label).save({ ...labelInfo, color: color.rgb, project });
+  return newLabel.id;
+};
+export const deleteLabel = async (labelId: number) => {
+  return getRepository(Label).createQueryBuilder().delete().where({ id: labelId }).execute();
+};

--- a/server/src/services/mindmap.ts
+++ b/server/src/services/mindmap.ts
@@ -10,7 +10,7 @@ interface INode {
   children?: string;
 }
 
-const findOneNode = (nodeId: number) => {
+export const findOneNode = (nodeId: number) => {
   const id = nodeId.toString(10);
   return getRepository(Mindmap).findOne({ where: { id } });
 };

--- a/server/src/services/sprint.ts
+++ b/server/src/services/sprint.ts
@@ -1,0 +1,6 @@
+import { getRepository } from 'typeorm';
+import { Sprint } from '../database/entities/Sprint';
+
+export const findOneSprint = async (id: string) => {
+  return getRepository(Sprint).findOne({ where: { id } });
+};

--- a/server/src/services/sprint.ts
+++ b/server/src/services/sprint.ts
@@ -1,6 +1,18 @@
 import { getRepository } from 'typeorm';
+import { findOneProject } from './project';
+import { TAddSprint } from '../utils/event-type';
 import { Sprint } from '../database/entities/Sprint';
+import { Color } from '../database/entities/Color';
 
 export const findOneSprint = async (id: string) => {
   return getRepository(Sprint).findOne({ where: { id } });
+};
+export const createSprint = async (projectId: string, sprintInfo: TAddSprint) => {
+  const project = await findOneProject(projectId);
+  const color = await getRepository(Color).createQueryBuilder().orderBy('RAND()').getOne();
+  const newSprint = await getRepository(Sprint).save({ ...sprintInfo, project, color: color.rgb });
+  return newSprint.id;
+};
+export const deleteSprint = async (sprintId: number) => {
+  return getRepository(Sprint).createQueryBuilder().delete().where({ id: sprintId }).execute();
 };

--- a/server/src/services/task.ts
+++ b/server/src/services/task.ts
@@ -6,13 +6,6 @@ import { findOneNode } from './mindmap';
 import { findOneSprint } from './sprint';
 import { findOneUser } from './user';
 
-type TTask = {
-  priority?: string;
-  dueDate?: string;
-  estimatedTime?: string;
-  finishedTime?: string;
-};
-
 export const findOneTask = async (nodeId: string) => {
   return getRepository(Task).findOne({ relations: ['nodeId'], where: { nodeId } });
 };
@@ -33,42 +26,24 @@ const findOneOrCreate = async (taskId: number) => {
   return findOneTask(taskId.toString(10));
 };
 
-const updateTaskInformation = async (task: Task, newData: TTask) => {
-  const newTask = { ...task, ...newData };
-  return getRepository(Task).save(newTask);
-};
-
-const updateTaskAssignee = async (task: Task, assigneeId: number) => {
-  const assignee = await findOneUser(assigneeId.toString(10));
-  task.assignee = assignee;
-  return getRepository(Task).save(task);
-};
-
-const updateTaskSprint = async (task: Task, sprintId: number) => {
-  const sprint = await findOneSprint(sprintId.toString(10));
-  task.sprint = sprint;
-  return getRepository(Task).save(task);
-};
-
-const updateTaskLabel = async (task: Task, labelIds: number[]) => {
-  const labels = await getRepository(Label).findByIds(labelIds);
-  task.labels = labels;
-  return getRepository(Task).save(task);
-};
-
 export const updateTask = async (nodeFrom: number, { changed }: TUpdateTaskInformation) => {
   const { assignee, labels, sprint, ...info } = changed;
   const task = await findOneOrCreate(nodeFrom);
   if (assignee) {
-    await updateTaskAssignee(task, assignee);
+    const newAssignee = await findOneUser(assignee.toString(10));
+    task.assignee = newAssignee;
   }
   if (labels) {
-    await updateTaskLabel(task, labels);
+    const newLabels = await getRepository(Label).findByIds(labels);
+    task.labels = newLabels;
   }
   if (sprint) {
-    await updateTaskSprint(task, sprint);
+    const newSprint = await findOneSprint(sprint.toString(10));
+    task.sprint = newSprint;
   }
   if (info) {
-    await updateTaskInformation(task, info);
+    const newTask = { ...task, ...info };
+    return getRepository(Task).save(newTask);
   }
+  return getRepository(Task).save(task);
 };

--- a/server/src/services/task.ts
+++ b/server/src/services/task.ts
@@ -1,0 +1,74 @@
+import { getRepository } from 'typeorm';
+import { Label } from '../database/entities/Label';
+import { Task } from '../database/entities/Task';
+import { TUpdateTaskInformation } from '../utils/event-type';
+import { findOneNode } from './mindmap';
+import { findOneSprint } from './sprint';
+import { findOneUser } from './user';
+
+type TTask = {
+  priority?: string;
+  dueDate?: string;
+  estimatedTime?: string;
+  finishedTime?: string;
+};
+
+export const findOneTask = async (nodeId: string) => {
+  return getRepository(Task).findOne({ relations: ['nodeId'], where: { nodeId } });
+};
+
+export const createTask = async (taskId: number) => {
+  const node = await findOneNode(taskId);
+  return getRepository(Task).save({ nodeId: node });
+};
+
+export const deleteTask = async (taskId: number) => {
+  return getRepository(Task).createQueryBuilder('task').leftJoin('task.nodeId', 'nodeId').delete().where({ nodeId: taskId }).execute();
+};
+
+const findOneOrCreate = async (taskId: number) => {
+  const task = await findOneTask(taskId.toString(10));
+  if (task !== undefined) return task;
+  await createTask(taskId);
+  return findOneTask(taskId.toString(10));
+};
+
+const updateTaskInformation = async (task: Task, newData: TTask) => {
+  const newTask = { ...task, ...newData };
+  return getRepository(Task).save(newTask);
+};
+
+const updateTaskAssignee = async (task: Task, assigneeId: number) => {
+  const assignee = await findOneUser(assigneeId.toString(10));
+  task.assignee = assignee;
+  return getRepository(Task).save(task);
+};
+
+const updateTaskSprint = async (task: Task, sprintId: number) => {
+  const sprint = await findOneSprint(sprintId.toString(10));
+  task.sprint = sprint;
+  return getRepository(Task).save(task);
+};
+
+const updateTaskLabel = async (task: Task, labelIds: number[]) => {
+  const labels = await getRepository(Label).findByIds(labelIds);
+  task.labels = labels;
+  return getRepository(Task).save(task);
+};
+
+export const updateTask = async (nodeFrom: number, { changed }: TUpdateTaskInformation) => {
+  const { assignee, labels, sprint, ...info } = changed;
+  const task = await findOneOrCreate(nodeFrom);
+  if (assignee) {
+    await updateTaskAssignee(task, assignee);
+  }
+  if (labels) {
+    await updateTaskLabel(task, labels);
+  }
+  if (sprint) {
+    await updateTaskSprint(task, sprint);
+  }
+  if (info) {
+    await updateTaskInformation(task, info);
+  }
+};

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -7,7 +7,9 @@ enum EventArgs {
   'user' = 5,
   'data' = 7,
 }
+
 type THistoryEventFunction = (data?: eventType.THistoryEventData, project?: string, user?: number) => Promise<number> | void;
+type TEventFunction = (data?: eventType.TEventData, project?: string, user?: number) => Promise<number> | void;
 
 const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEventFunction> => {
   return {
@@ -18,11 +20,51 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
       deleteNode(nodeFrom, (dataFrom as eventType.TDeleteNodeData).nodeId);
       return;
     },
+    MOVE_NODE: ({ nodeTo, dataTo }) => {
+      updateNode(nodeTo, dataTo as eventType.TMoveNodeData);
+      return;
+    },
+    UPDATE_NODE_PARENT: ({ nodeFrom, nodeTo, dataTo }) => {
+      return;
+    },
+    UPDATE_NODE_SIBLING: ({ nodeFrom, dataTo }) => {
+      return;
+    },
     UPDATE_NODE_CONTENT: ({ nodeFrom, dataTo }) => {
       updateNode(nodeFrom, dataTo as eventType.TUpdateNodeContent);
       return;
     },
-    MOVE_NODE: () => {
+    UPDATE_TASK_INFORMATION: ({ nodeFrom, dataTo }) => {
+      const { changed } = dataTo as eventType.TUpdateTaskInformation;
+      return;
+    },
+  };
+};
+
+const eventFunction = (): Record<eventType.TEventType, TEventFunction> => {
+  return {
+    ADD_SPRINT: (data, project) => {
+      const { name, startDate, dueDate } = data as eventType.TAddSprint;
+      return;
+    },
+    ADD_LABEL: (data, project) => {
+      const { name } = data as eventType.TAddLabel;
+      return;
+    },
+    ADD_COMMENT: (data, project) => {
+      const { nodeId, comment } = data as eventType.TAddComment;
+      return;
+    },
+    DELETE_SPRINT: (data, project) => {
+      const { sprintId } = data as eventType.TDeleteSprint;
+      return;
+    },
+    DELETE_LABEL: (data, project) => {
+      const { labelId } = data as eventType.TDeleteLabel;
+      return;
+    },
+    DELETE_COMMENT: (data, project) => {
+      const { nodeId, commentId } = data as eventType.TDeleteComment;
       return;
     },
   };
@@ -31,4 +73,9 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
 export const convertHistoryEvent = (args: string[]) => {
   const [type, project, user, data] = ['type', 'project', 'user', 'data'].map((str) => args[EventArgs[str]]);
   return historyEventFunction()[type](JSON.parse(data), project, user);
+};
+
+export const convertEvent = (args: string[]) => {
+  const [type, project, user, data] = ['type', 'project', 'user', 'data'].map((str) => args[EventArgs[str]]);
+  return eventFunction()[type](JSON.parse(data), project, user);
 };

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -1,4 +1,8 @@
 import { createNode, updateNode, updateNodeParent, deleteNode } from '../services/mindmap';
+import { updateTask } from '../services/task';
+import { createSprint, deleteSprint } from '../services/sprint';
+import { createLabel, deleteLabel } from '../services/label';
+import { createComment, deleteComment } from '../services/comment';
 import * as eventType from './event-type';
 
 enum EventArgs {
@@ -38,7 +42,7 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
       return;
     },
     UPDATE_TASK_INFORMATION: ({ nodeFrom, dataTo }) => {
-      const { changed } = dataTo as eventType.TUpdateTaskInformation;
+      updateTask(nodeFrom, dataTo as eventType.TUpdateTaskInformation);
       return;
     },
   };
@@ -47,27 +51,27 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
 const eventFunction = (): Record<eventType.TEventType, TEventFunction> => {
   return {
     ADD_SPRINT: (data, project) => {
-      const { name, startDate, dueDate } = data as eventType.TAddSprint;
-      return;
+      return createSprint(project, data as eventType.TAddSprint);
     },
     ADD_LABEL: (data, project) => {
-      const { name } = data as eventType.TAddLabel;
-      return;
+      return createLabel(project, data as eventType.TAddLabel);
     },
-    ADD_COMMENT: (data, project) => {
-      const { nodeId, comment } = data as eventType.TAddComment;
-      return;
+    ADD_COMMENT: (data) => {
+      return createComment(data as eventType.TAddComment);
     },
-    DELETE_SPRINT: (data, project) => {
+    DELETE_SPRINT: (data) => {
       const { sprintId } = data as eventType.TDeleteSprint;
+      deleteSprint(sprintId);
       return;
     },
-    DELETE_LABEL: (data, project) => {
+    DELETE_LABEL: (data) => {
       const { labelId } = data as eventType.TDeleteLabel;
+      deleteLabel(labelId);
       return;
     },
-    DELETE_COMMENT: (data, project) => {
-      const { nodeId, commentId } = data as eventType.TDeleteComment;
+    DELETE_COMMENT: (data) => {
+      const { commentId } = data as eventType.TDeleteComment;
+      deleteComment(commentId);
       return;
     },
   };

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -1,5 +1,5 @@
 import { createNode, updateNode, updateNodeParent, deleteNode } from '../services/mindmap';
-import { updateTask } from '../services/task';
+import { deleteTask, updateTask } from '../services/task';
 import { createSprint, deleteSprint } from '../services/sprint';
 import { createLabel, deleteLabel } from '../services/label';
 import { createComment, deleteComment } from '../services/comment';
@@ -29,7 +29,9 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
       return;
     },
     UPDATE_NODE_PARENT: ({ nodeFrom, nodeTo, dataTo }) => {
-      updateNodeParent(nodeFrom, nodeTo, (dataTo as eventType.TUpdateNodeParent).nodeId);
+      const { nodeId, nodeParentType } = dataTo as eventType.TUpdateNodeParent;
+      updateNodeParent(nodeFrom, nodeTo, nodeId);
+      if (nodeParentType !== 'Story') deleteTask(nodeId);
       return;
     },
     UPDATE_NODE_SIBLING: ({ dataTo }) => {

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -28,7 +28,9 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
       updateNodeParent(nodeFrom, nodeTo, (dataTo as eventType.TUpdateNodeParent).nodeId);
       return;
     },
-    UPDATE_NODE_SIBLING: ({ nodeFrom, dataTo }) => {
+    UPDATE_NODE_SIBLING: ({ dataTo }) => {
+      const { parentId, children } = dataTo as eventType.TUpdateNodeSibling;
+      updateNode(parentId, { children: JSON.stringify(children) });
       return;
     },
     UPDATE_NODE_CONTENT: ({ nodeFrom, dataTo }) => {

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -7,19 +7,19 @@ enum EventArgs {
   'user' = 5,
   'data' = 7,
 }
-type TEventFunction = (data?: eventType.TEventData, project?: string, user?: number) => Promise<number> | void;
+type THistoryEventFunction = (data?: eventType.THistoryEventData, project?: string, user?: number) => Promise<number> | void;
 
-const eventFunction = (): Record<eventType.TEventType, TEventFunction> => {
+const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEventFunction> => {
   return {
     ADD_NODE: ({ nodeFrom, dataTo }, project: string) => {
-      return createNode(project, nodeFrom, dataTo);
+      return createNode(project, nodeFrom, dataTo as eventType.TAddNodeData);
     },
     DELETE_NODE: ({ nodeFrom, dataFrom }) => {
       deleteNode(nodeFrom, (dataFrom as eventType.TDeleteNodeData).nodeId);
       return;
     },
     UPDATE_NODE_CONTENT: ({ nodeFrom, dataTo }) => {
-      updateNode(nodeFrom, dataTo);
+      updateNode(nodeFrom, dataTo as eventType.TUpdateNodeContent);
       return;
     },
     MOVE_NODE: () => {
@@ -28,7 +28,7 @@ const eventFunction = (): Record<eventType.TEventType, TEventFunction> => {
   };
 };
 
-export const convertEvent = (args: string[]) => {
+export const convertHistoryEvent = (args: string[]) => {
   const [type, project, user, data] = ['type', 'project', 'user', 'data'].map((str) => args[EventArgs[str]]);
-  return eventFunction()[type](JSON.parse(data), project, user);
+  return historyEventFunction()[type](JSON.parse(data), project, user);
 };

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -1,4 +1,4 @@
-import { createNode, updateNode, deleteNode } from '../services/mindmap';
+import { createNode, updateNode, updateNodeParent, deleteNode } from '../services/mindmap';
 import * as eventType from './event-type';
 
 enum EventArgs {
@@ -25,6 +25,7 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
       return;
     },
     UPDATE_NODE_PARENT: ({ nodeFrom, nodeTo, dataTo }) => {
+      updateNodeParent(nodeFrom, nodeTo, (dataTo as eventType.TUpdateNodeParent).nodeId);
       return;
     },
     UPDATE_NODE_SIBLING: ({ nodeFrom, dataTo }) => {

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -1,32 +1,28 @@
 import { createNode, updateNode, deleteNode } from '../services/mindmap';
+import * as eventType from './event-type';
 
-type TEventType = 'ADD_NODE' | 'DELETE_NODE' | 'UPDATE_NODE_CONTENT' | 'MOVE_NODE';
 enum EventArgs {
   'type' = 1,
   'project' = 3,
   'user' = 5,
   'data' = 7,
 }
+type TEventFunction = (data?: eventType.TEventData, project?: string, user?: number) => Promise<number> | void;
 
-const eventFunction = (): Record<TEventType, (...args) => void> => {
+const eventFunction = (): Record<eventType.TEventType, TEventFunction> => {
   return {
-    ADD_NODE: (data: string, project: string) => {
-      const { nodeFrom, dataTo } = JSON.parse(data);
+    ADD_NODE: ({ nodeFrom, dataTo }, project: string) => {
       return createNode(project, nodeFrom, dataTo);
     },
-    DELETE_NODE: (data: string) => {
-      const { nodeFrom, dataFrom } = JSON.parse(data);
-      deleteNode(nodeFrom, dataFrom.nodeId);
+    DELETE_NODE: ({ nodeFrom, dataFrom }) => {
+      deleteNode(nodeFrom, (dataFrom as eventType.TDeleteNodeData).nodeId);
       return;
     },
-    UPDATE_NODE_CONTENT: (data: string) => {
-      const { nodeFrom, dataTo } = JSON.parse(data);
+    UPDATE_NODE_CONTENT: ({ nodeFrom, dataTo }) => {
       updateNode(nodeFrom, dataTo);
       return;
     },
-    MOVE_NODE: (data: string) => {
-      if (data) {
-      }
+    MOVE_NODE: () => {
       return;
     },
   };
@@ -34,5 +30,5 @@ const eventFunction = (): Record<TEventType, (...args) => void> => {
 
 export const convertEvent = (args: string[]) => {
   const [type, project, user, data] = ['type', 'project', 'user', 'data'].map((str) => args[EventArgs[str]]);
-  return eventFunction()[type](data, project, user);
+  return eventFunction()[type](JSON.parse(data), project, user);
 };

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -1,10 +1,3 @@
-export type TEventType = 'ADD_NODE' | 'DELETE_NODE' | 'UPDATE_NODE_CONTENT' | 'MOVE_NODE';
-export type TEventData = {
-  nodeFrom: number | null;
-  nodeTo: number | null;
-  dataFrom: TDeleteNodeData | TAddNodeData | null;
-  dataTo: Record<string, any>;
-};
 export type TDeleteNodeData = {
   nodeId: number;
   content: string;
@@ -18,7 +11,7 @@ export type TDeleteNodeData = {
 export type TAddNodeData = {
   content: string;
 };
-export type TMoveNodeDate = {
+export type TMoveNodeData = {
   posX?: number;
   posY?: number;
 };
@@ -41,6 +34,13 @@ export type TTask = {
   finishedTime?: string;
   sprint?: string;
 };
-export type TUpdateTaskInfo = {
+export type TUpdateTaskInformation = {
   changed: TTask;
+};
+export type THistoryEventType = 'ADD_NODE' | 'DELETE_NODE' | 'UPDATE_NODE_CONTENT' | 'MOVE_NODE';
+export type THistoryEventData = {
+  nodeFrom: number | null;
+  nodeTo: number | null;
+  dataFrom: TDeleteNodeData | TMoveNodeData | TUpdateNodeParent | TUpdateNodeSibling | TUpdateNodeContent | TUpdateTaskInformation | null;
+  dataTo: TAddNodeData | TMoveNodeData | TUpdateNodeParent | TUpdateNodeSibling | TUpdateNodeContent | TUpdateTaskInformation | null;
 };

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -1,0 +1,46 @@
+export type TEventType = 'ADD_NODE' | 'DELETE_NODE' | 'UPDATE_NODE_CONTENT' | 'MOVE_NODE';
+export type TEventData = {
+  nodeFrom: number | null;
+  nodeTo: number | null;
+  dataFrom: TDeleteNodeData | TAddNodeData | null;
+  dataTo: Record<string, any>;
+};
+export type TDeleteNodeData = {
+  nodeId: number;
+  content: string;
+  index: number;
+  status?: string;
+  posX?: number;
+  posY?: number;
+  assignee?: number;
+  priority?: string;
+};
+export type TAddNodeData = {
+  content: string;
+};
+export type TMoveNodeDate = {
+  posX?: number;
+  posY?: number;
+};
+export type TUpdateNodeParent = {
+  nodeId: number;
+};
+export type TUpdateNodeSibling = {
+  parentId: number;
+  children: number[];
+};
+export type TUpdateNodeContent = {
+  content: string;
+};
+export type TTask = {
+  assignee?: number;
+  label?: number[];
+  priority?: string;
+  dueDate?: string;
+  estimatedTime?: string;
+  finishedTime?: string;
+  sprint?: string;
+};
+export type TUpdateTaskInfo = {
+  changed: TTask;
+};

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -17,6 +17,7 @@ export type TMoveNodeData = {
 };
 export type TUpdateNodeParent = {
   nodeId: number;
+  nodeParentType: 'Project' | 'Epic' | 'Story';
 };
 export type TUpdateNodeSibling = {
   parentId: number;

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -27,12 +27,12 @@ export type TUpdateNodeContent = {
 };
 export type TTask = {
   assignee?: number;
-  label?: number[];
+  labels?: number[];
   priority?: string;
   dueDate?: string;
   estimatedTime?: string;
   finishedTime?: string;
-  sprint?: string;
+  sprint?: number;
 };
 export type TUpdateTaskInformation = {
   changed: TTask;
@@ -40,7 +40,7 @@ export type TUpdateTaskInformation = {
 export type TAddSprint = {
   name: string;
   startDate: string;
-  dueDate: string;
+  endDate: string;
 };
 export type TAddLabel = {
   name: string;

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -3,8 +3,8 @@ export type TDeleteNodeData = {
   content: string;
   index: number;
   status?: string;
-  posX?: number;
-  posY?: number;
+  posX?: string;
+  posY?: string;
   assignee?: number;
   priority?: string;
 };
@@ -12,8 +12,8 @@ export type TAddNodeData = {
   content: string;
 };
 export type TMoveNodeData = {
-  posX?: number;
-  posY?: number;
+  posX?: string;
+  posY?: string;
 };
 export type TUpdateNodeParent = {
   nodeId: number;
@@ -37,10 +37,43 @@ export type TTask = {
 export type TUpdateTaskInformation = {
   changed: TTask;
 };
-export type THistoryEventType = 'ADD_NODE' | 'DELETE_NODE' | 'UPDATE_NODE_CONTENT' | 'MOVE_NODE';
+export type TAddSprint = {
+  name: string;
+  startDate: string;
+  dueDate: string;
+};
+export type TAddLabel = {
+  name: string;
+};
+export type TAddComment = {
+  nodeId: number;
+  comment: string;
+};
+export type TDeleteSprint = {
+  sprintId: number;
+};
+export type TDeleteLabel = {
+  labelId: number;
+};
+export type TDeleteComment = {
+  nodeId: number;
+  commentId: number;
+};
+
+export type THistoryEventType =
+  | 'ADD_NODE'
+  | 'DELETE_NODE'
+  | 'MOVE_NODE'
+  | 'UPDATE_NODE_PARENT'
+  | 'UPDATE_NODE_SIBLING'
+  | 'UPDATE_NODE_CONTENT'
+  | 'UPDATE_TASK_INFORMATION';
 export type THistoryEventData = {
   nodeFrom: number | null;
   nodeTo: number | null;
   dataFrom: TDeleteNodeData | TMoveNodeData | TUpdateNodeParent | TUpdateNodeSibling | TUpdateNodeContent | TUpdateTaskInformation | null;
   dataTo: TAddNodeData | TMoveNodeData | TUpdateNodeParent | TUpdateNodeSibling | TUpdateNodeContent | TUpdateTaskInformation | null;
 };
+
+export type TEventType = 'ADD_SPRINT' | 'ADD_LABEL' | 'ADD_COMMENT' | 'DELETE_SPRINT' | 'DELETE_LABEL' | 'DELETE_COMMENT';
+export type TEventData = TAddSprint | TAddLabel | TAddComment | TDeleteSprint | TDeleteLabel | TDeleteComment;

--- a/server/src/utils/socket.ts
+++ b/server/src/utils/socket.ts
@@ -2,7 +2,7 @@ import { Server, Socket } from 'socket.io';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import { xread, xadd } from './redis';
-import { convertHistoryEvent } from './event-converter';
+import { convertHistoryEvent, convertEvent } from './event-converter';
 import { getUserHasProject, addUserToProject } from '../services/project';
 
 dotenv.config();
@@ -75,12 +75,17 @@ const socketIO = (server, origin) => {
       socket.disconnect();
     });
 
-    socket.on('event', (type, data) => {
+    socket.on('history-event', (type, data) => {
       xread(projectId, '$', handleNewEvent);
       xadd({
         stream: projectId,
         args: ['type', type, 'projectId', projectId, 'user', id, 'data', data],
       });
+    });
+    socket.on('non-history-event', async (type, data) => {
+      const eventData = ['type', type, 'projectId', projectId, 'user', id, 'data', data];
+      const dbData = await convertEvent(eventData);
+      io.in(projectId).emit('event', eventData, dbData);
     });
   });
 };

--- a/server/src/utils/socket.ts
+++ b/server/src/utils/socket.ts
@@ -2,7 +2,7 @@ import { Server, Socket } from 'socket.io';
 import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import { xread, xadd } from './redis';
-import { convertEvent } from './event-converter';
+import { convertHistoryEvent } from './event-converter';
 import { getUserHasProject, addUserToProject } from '../services/project';
 
 dotenv.config();
@@ -41,7 +41,7 @@ const socketIO = (server, origin) => {
 
     const handleNewEvent = async (data: Record<number, object>) => {
       const eventData = data[0][1][0][1];
-      const dbData = await convertEvent(eventData);
+      const dbData = await convertHistoryEvent(eventData);
       io.in(projectId).emit('event', eventData, dbData);
     };
 


### PR DESCRIPTION
## 📑 제목
히스토리 DB 저장
## 📎 관련 이슈
- #59 
## ✔️ 셀프 체크리스트
- [x] 소켓으로 히스토리를 받고, 보내기
- [x] Redis에 히스토리 저장
- [x] Mysql에 노드 업데이트
## 💬 작업 내용
- Entity 수정 및 생성
- Service 정의
## 🚧 PR 특이 사항
- `convertEvent`, `convertHistoryEvent`는 test api로 요청 보내는 식으로 테스트해서, 소켓 연결 후 동작은 해 봐야 안다.
- `utils/event-type`에 쓰이는 타입은 다 정의해 놓았으므로 참고
- `socket.on('non-history-event', async (type, data)` 와 `socket.on('history-event', (type, data)` 로 받는 이벤트 이름이 나뉘었다. 내보내는 이벤트는 `event`로 동일한데 불편하면 받는 이름과 동일하게 분리해도 됨.
- `UPDATE_NODE_PARENT` 에서 이동한 parent의 타입 (project,epic,story)에 따라 부모가 story가 아니면 task 테이블에서 지우도록 함. 따라서 추가적으로 `nodeParentType`를 `dataTo`에 넣어야 하고, 테스트한 부분은 아니라서 역시 소켓 연결 후 확인 필요
## 🕰 실제 소요 시간
45h