### PR TITLE
History API

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["Mindmap", "typeorm", "xadd", "xread"]
+  "cSpell.words": ["Mindmap", "typeorm", "xadd", "xread", "xrevrange"]
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -37,7 +37,7 @@
         "lint-staged": "^11.2.6",
         "nodemon": "^2.0.14",
         "ts-node": "3.3.0",
-        "typescript": "3.3.3333"
+        "typescript": "^4.6.0-dev.20211116"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -346,6 +346,20 @@
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/@typescript-eslint/experimental-utils": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.1.tgz",
@@ -510,6 +524,20 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -6175,9 +6203,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "version": "4.6.0-dev.20211116",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-dev.20211116.tgz",
+      "integrity": "sha512-Z7SBOG6T/WRwP0zkxIzzn+TZxUgO+eM0YUfeSlU9mEiJOqxCaMyKhH42v+mQ/Ma3Dtsqe4D+vmrPGthZcETZeQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -6849,6 +6877,13 @@
           "requires": {
             "tslib": "^1.8.1"
           }
+        },
+        "typescript": {
+          "version": "4.4.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+          "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -6950,6 +6985,13 @@
           "requires": {
             "tslib": "^1.8.1"
           }
+        },
+        "typescript": {
+          "version": "4.4.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
+          "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+          "dev": true,
+          "peer": true
         }
       }
     },
@@ -11202,9 +11244,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "version": "4.6.0-dev.20211116",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.0-dev.20211116.tgz",
+      "integrity": "sha512-Z7SBOG6T/WRwP0zkxIzzn+TZxUgO+eM0YUfeSlU9mEiJOqxCaMyKhH42v+mQ/Ma3Dtsqe4D+vmrPGthZcETZeQ==",
       "dev": true
     },
     "unbox-primitive": {

--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,7 @@
     "lint-staged": "^11.2.6",
     "nodemon": "^2.0.14",
     "ts-node": "3.3.0",
-    "typescript": "3.3.3333"
+    "typescript": "^4.6.0-dev.20211116"
   },
   "scripts": {
     "start": "nodemon src/index.ts",

--- a/server/src/routes/history.ts
+++ b/server/src/routes/history.ts
@@ -1,0 +1,16 @@
+import { Router, Request, Response } from 'express';
+import { xrevrange } from '../utils';
+const router = Router();
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  try {
+    const { projectId } = req.params;
+    const { rangeFrom, count } = req.body;
+    const history: Array<string | string[]> = await xrevrange({ projectId, from: rangeFrom ?? '+', to: '-', count: count ?? 30 });
+    res.status(200).send(history);
+  } catch (e) {
+    res.status(500).send(e.message);
+  }
+});
+
+export default router;

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,11 +2,13 @@ import { Router } from 'express';
 import authRouter from './auth';
 import userRouter from './user';
 import projectRouter from './project';
+import historyRouter from './history';
 
 const router = Router();
 
 router.use('/auth', authRouter);
 router.use('/user', userRouter);
 router.use('/project', projectRouter);
+router.use('/history', historyRouter);
 
 export default router;

--- a/server/src/utils/redis.ts
+++ b/server/src/utils/redis.ts
@@ -7,21 +7,30 @@ export const xread = (stream: string, id: string, callback: (str) => void) => {
     port: 6379,
     host: process.env.REDIS_HOST,
   });
-  xreadClient.xread('BLOCK', 0, 'STREAMS', stream, id, (err, str) => {
+  xreadClient.xread('BLOCK', 0, 'STREAMS', stream, id, (err, result) => {
     if (err) throw err;
-    callback(str);
+    callback(result);
     xreadClient.quit();
   });
 };
 
-const xaddClient = redis.createClient({
+const redisClient = redis.createClient({
   port: 6379,
   host: process.env.REDIS_HOST,
 });
 export const xadd = ({ stream, args }: { stream: string; args: string[] }) => {
-  xaddClient.xadd(stream, '*', ...args, (err, ErrorStream) => {
+  redisClient.xadd(stream, '*', ...args, (err, result) => {
     if (err) throw err;
-    if (ErrorStream) {
+    if (result) {
     }
+  });
+};
+
+export const xrevrange = ({ projectId, from, to, count }: Record<string, string>) => {
+  return new Promise<Array<string | string[]>>((resolve) => {
+    redisClient.xrevrange(projectId, from, to, 'COUNT', count, (err, result) => {
+      if (err) throw err;
+      resolve(result);
+    });
   });
 };


### PR DESCRIPTION
## 📑 제목
History API
## 📎 관련 이슈
- #102 
## ✔️ 셀프 체크리스트
- [ ] 스냅샷 
- [x] 히스토리
- [x] 특정 개수로 끊어서 보내기
## 💬 작업 내용
- 프로젝트 히스토리를 보내주는 api
## 🚧 PR 특이 사항
- api/history/:projectId 로 접근
- req.body에 rangeFrom(데이터 id), count(불러올 개수) 넣으면 범위 특정 가능
- 기본 값은 최신 30 개
- rangeFrom 에 `(1636604005367-0` 처럼 앞에 '(' 넣으면 그 아이디 다음 값부터 불러옴. '(' 없으면 포함 ( [xrevrange](https://redis.io/commands/xrevrange) , [xrange](https://redis.io/commands/xrange) )
- Typescript 버전 업
  - Nullish coalescing operator(??) 사용 위함.
  - vscode에 `JavaScript and TypeScript Nightly` 확장 설치.
- 스냅샷 관련은 나중에 하겠음

## 🕰 실제 소요 시간
- 2h