### PR TITLE
mindmap 더미 데이터 삭제 후 DB 데이터 연동

### DIFF
--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -17,11 +17,10 @@ interface ITreeProps {
 }
 
 const TEMP_NODE_ID = -1;
-const ROOT_NODE_ID = 0;
 
 const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId }) => {
-  const isRoot = nodeId === ROOT_NODE_ID;
   const { rootId, mindNodes } = mindmapData;
+  const isRoot = nodeId === rootId;
   const node = mindNodes.get(nodeId);
   const { level, content, children } = node!;
 
@@ -65,7 +64,7 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId
   const addNewNode = (nodeContent: string) => {
     const payload = {
       nodeFrom: parentId!,
-      dataTo: { content: nodeContent },
+      dataTo: { content: nodeContent, level: level },
     };
 
     addNode(payload);

--- a/client/src/components/organisms/MindmapBtnWrapper/index.tsx
+++ b/client/src/components/organisms/MindmapBtnWrapper/index.tsx
@@ -18,7 +18,7 @@ const TEMP_NODE_ID = -1;
 
 const createTempNode = ({ mindmapData, selectedNodeId }: ITempNodeParams) => {
   const { rootId, mindNodes } = mindmapData;
-  const parentNode = { ...mindNodes.get(selectedNodeId ?? 0) } as IMindNode;
+  const parentNode = { ...mindNodes.get(selectedNodeId ?? rootId) } as IMindNode;
   const level = getChildLevel(parentNode!.level!);
 
   const tempNode = { nodeId: TEMP_NODE_ID, level: level, content: '', children: [] };

--- a/client/src/components/templates/MindmapTemplate/index.tsx
+++ b/client/src/components/templates/MindmapTemplate/index.tsx
@@ -5,9 +5,10 @@ import { Mindmap, MindmapBtnWrapper } from 'components/organisms';
 
 const MindmapTemplate: React.FC = () => {
   const mindmapData = useRecoilValue(mindmapState);
+  const isLoaded = !!(mindmapData.rootId !== -1);
   return (
     <MindmapBackground className='mindmap-area background'>
-      <Mindmap mindmapData={mindmapData} />
+      {isLoaded && <Mindmap mindmapData={mindmapData} />}
       <MindmapBtnWrapper />
     </MindmapBackground>
   );

--- a/client/src/recoil/mindmap/index.ts
+++ b/client/src/recoil/mindmap/index.ts
@@ -2,7 +2,7 @@ import { atom, selector } from 'recoil';
 import { IMindmapData } from 'types/mindmap';
 
 export const getNextMapState = (prevState: IMindmapData) => {
-  const nextNodes = new Map(prevState.mindNodes);
+  const nextNodes = new Map(prevState.mindNodes!);
   nextNodes.forEach((value, key, mapObject) => mapObject.set(key, { ...value, children: [...value.children] }));
 
   return {
@@ -11,34 +11,11 @@ export const getNextMapState = (prevState: IMindmapData) => {
   };
 };
 
-///더미코드 삭제 예정
-const getDummyMindmapData = (): IMindmapData => {
-  const mindNodes = new Map();
-  Array(10)
-    .fill(0)
-    .map((v, i) => ({ nodeId: i + 10, level: 'TASK', content: 'TASK', children: [] }))
-    .forEach((v) => mindNodes.set(v.nodeId, v));
-  [
-    { nodeId: 9, level: 'STORY', content: 'STORY', children: [10, 11] },
-    { nodeId: 8, level: 'STORY', content: 'STORY', children: [12, 19] },
-    { nodeId: 7, level: 'STORY', content: 'STORY', children: [] },
-    { nodeId: 6, level: 'STORY', content: 'STORY', children: [13, 14, 15] },
-    { nodeId: 5, level: 'STORY', content: 'STORY', children: [16] },
-    { nodeId: 4, level: 'STORY', content: 'STORY', children: [17, 18] },
-    { nodeId: 3, level: 'EPIC', content: 'EPIC', children: [] },
-    { nodeId: 2, level: 'EPIC', content: 'EPIC', children: [4, 5, 6, 7] },
-    { nodeId: 1, level: 'EPIC', content: 'EPIC', children: [8, 9] },
-    { nodeId: 0, level: 'ROOT', content: 'ROOT', children: [1, 2, 3] },
-  ].forEach((v) => mindNodes.set(v.nodeId, v));
-  return {
-    rootId: 0,
-    mindNodes: mindNodes,
-  };
-};
+const TEMP_NODE_ID = -1;
 
 export const mindmapState = atom<IMindmapData>({
   key: 'mindmapAtom',
-  default: getDummyMindmapData(),
+  default: { rootId: TEMP_NODE_ID, mindNodes: new Map() },
 });
 
 export const mindmapNodesState = selector({

--- a/client/src/types/event.ts
+++ b/client/src/types/event.ts
@@ -10,6 +10,7 @@ export type TDeleteNodeData = {
 };
 export type TAddNodeData = {
   content: string;
+  level: string;
 };
 export type TMoveNodeData = {
   posX?: string;

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -39,6 +39,12 @@ export const project = {
     });
     return userList;
   },
+  getInfo: async (projectId: string) => {
+    const info = await api.get('/project/info', {
+      params: { projectId },
+    });
+    return info;
+  },
 };
 
 export const API = {

--- a/server/src/database/entities/Mindmap.ts
+++ b/server/src/database/entities/Mindmap.ts
@@ -22,6 +22,9 @@ export class Mindmap {
   @Column({ default: null })
   posY: string;
 
+  @Column()
+  level: string;
+
   @CreateDateColumn()
   createdAt: Date;
 

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -45,10 +45,11 @@ router.get('/user-list', async (req: Request, res: Response, next: Next) => {
   }
 });
 
-router.get('/:projectId', async (req: Request, res: Response, next: Next) => {
+router.get('/info', async (req: Request, res: Response, next: Next) => {
   try {
-    const { projectId } = req.params;
+    const { projectId } = req.query;
     const projectInfo = await projectService.getProjectInfo(projectId);
+    projectInfo.mindmap.forEach((node) => (node.children = JSON.parse(node.children)));
     res.send(projectInfo);
   } catch (e) {
     next(e);

--- a/server/src/services/mindmap.ts
+++ b/server/src/services/mindmap.ts
@@ -3,6 +3,7 @@ import { Mindmap } from '../database/entities/Mindmap';
 import { findOneProject } from './project';
 
 interface INode {
+  level?: string;
   label?: string;
   content?: string;
   posX?: string;

--- a/server/src/services/project.ts
+++ b/server/src/services/project.ts
@@ -44,7 +44,7 @@ export const addUserToProject = async (userId: string, projectId: string) => {
 export const createProject = async (name: string, creator: string) => {
   const user = await findOneUser(creator);
   const newProject = await getRepository(Project).save({ name, creator: user, users: [user] });
-  createNode(newProject.id, null, { content: name, posX: '0', posY: '0', children: JSON.stringify([]) });
+  createNode(newProject.id, null, { level: 'ROOT', content: name, posX: '0', posY: '0', children: JSON.stringify([]) });
   return newProject;
 };
 
@@ -64,6 +64,7 @@ export const getProjectInfo = async (projectId: string) => {
     .leftJoinAndSelect('project.users', 'users')
     .leftJoinAndSelect('project.sprints', 'sprints')
     .leftJoinAndSelect('project.labels', 'labels')
+    .leftJoinAndSelect('project.mindmap', 'mindmap')
     .where('project.id = :projectId', { projectId })
     .getOne();
 };

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -10,6 +10,7 @@ export type TDeleteNodeData = {
 };
 export type TAddNodeData = {
   content: string;
+  level: string;
 };
 export type TMoveNodeData = {
   posX?: string;


### PR DESCRIPTION
## 📑 제목
mindmap 더미 데이터 삭제 후 DB 데이터 연동

## 📎 관련 이슈
- #51

## ✔️ 셀프 체크리스트
- [X] 소켓 이벤트 정상 작동
- [X] DB에 데이터 정상 보존

## 💬 작업 내용
- DB에 level은 추가 추후에 사용하지 않으면 다시 제거하겠음
- api 이름 변경 /:projectId -> /info
- 더미 코드 삭제
- useSocketSetup에 init mindmap 로직 추가

## 🚧 PR 특이 사항
- DB에 level 추가하여서 DB 초기화 및 npm run seed 필요
- mindNode DB와 FE의 스키마가 달라 통합 필요

## 🕰 실제 소요 시간
5hr