### PR TITLE
프로젝트 칸반보드 페이지 UI, 작업상태 변경

### DIFF
--- a/client/src/components/atoms/SmallText/index.tsx
+++ b/client/src/components/atoms/SmallText/index.tsx
@@ -8,9 +8,9 @@ interface IStyleProps {
 }
 
 const SmallText = styled.p<IStyleProps>`
-  color: ${({ color }) => color};
-  font-size: ${({ theme }) => theme.fontSize.small};
-  font-weight: ${({ weight }) => (weight ? weight : 'normal')};
-  margin: ${({ margin }) => margin};
+  color: ${(props) => props.theme.color[props.color]};
+  font-size: ${(props) => props.theme.fontSize.small};
+  font-weight: ${({ weight }) => weight ?? 'normal'};
+  margin: ${({ margin }) => margin ?? '0'};
 `;
 export default SmallText;

--- a/client/src/components/atoms/Wrapper/index.tsx
+++ b/client/src/components/atoms/Wrapper/index.tsx
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+import { TFlex } from 'styles/common';
+
+interface IWrapper {
+  flex: TFlex;
+}
+
+const Wrapper = styled.div<IWrapper>`
+  ${({ theme, flex }) => theme.flex[flex]}
+`;
+
+export default Wrapper;

--- a/client/src/components/atoms/index.tsx
+++ b/client/src/components/atoms/index.tsx
@@ -12,3 +12,4 @@ export { default as Background } from 'components/atoms/Background';
 export { default as Node } from 'components/atoms/Node';
 export { default as UserIcon } from 'components/atoms/UserIcon';
 export { default as DragTarget } from 'components/atoms/DragTarget';
+export { default as Wrapper } from 'components/atoms/Wrapper';

--- a/client/src/components/molecules/LabelIcon/index.tsx
+++ b/client/src/components/molecules/LabelIcon/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { SmallText } from 'components/atoms';
+import { ILabel } from 'types/label';
+
+interface IProps {
+  label: ILabel;
+}
+
+const StyledLabelIcon = styled.div<IProps>`
+  background-color: ${({ label }) => `#${label.color}`};
+`;
+const LabelIcon: React.FC<IProps> = ({ label }) => {
+  return (
+    <StyledLabelIcon label={label}>
+      <SmallText color={'white'}>{label.name}</SmallText>;
+    </StyledLabelIcon>
+  );
+};
+
+export default LabelIcon;

--- a/client/src/components/molecules/TaskInfo/index.tsx
+++ b/client/src/components/molecules/TaskInfo/index.tsx
@@ -1,0 +1,23 @@
+import { SmallText, Wrapper } from 'components/atoms';
+import React from 'react';
+
+interface IProps {
+  title: string;
+  content: string;
+}
+
+const TaskInfo: React.FC<IProps> = ({ children, title, content }) => {
+  return (
+    <Wrapper flex={'rowCenter'}>
+      <SmallText color={'black'} margin={'3px 0'} weight={'bold'}>
+        {title}
+      </SmallText>
+      <SmallText color={'black'} margin={'0 0 0 5px'}>
+        {content}
+      </SmallText>
+      {children}
+    </Wrapper>
+  );
+};
+
+export default TaskInfo;

--- a/client/src/components/molecules/index.tsx
+++ b/client/src/components/molecules/index.tsx
@@ -12,3 +12,4 @@ export { default as Profile } from 'components/molecules/Profile';
 export { default as Spinner } from 'components/molecules/Spinner';
 export { default as HistoryWindow } from 'components/molecules/HistoryWindow';
 export { default as TempNode } from 'components/molecules/TempNode';
+export { default as TaskInfo } from 'components/molecules/TaskInfo';

--- a/client/src/components/molecules/index.tsx
+++ b/client/src/components/molecules/index.tsx
@@ -13,3 +13,4 @@ export { default as Spinner } from 'components/molecules/Spinner';
 export { default as HistoryWindow } from 'components/molecules/HistoryWindow';
 export { default as TempNode } from 'components/molecules/TempNode';
 export { default as TaskInfo } from 'components/molecules/TaskInfo';
+export { default as LabelIcon } from 'components/molecules/LabelIcon';

--- a/client/src/components/organisms/TaskCard/index.tsx
+++ b/client/src/components/organisms/TaskCard/index.tsx
@@ -15,7 +15,7 @@ const TaskCard: React.FC<IProps> = ({ taskInfo, onDoubleClickTask, onMouseDownTa
   const userList = useRecoilValue(userListState)!;
   const sprintList = useRecoilValue(sprintListState)!;
   const labelList = useRecoilValue(labelListState)!;
-  const user = userList.find((users) => users.id === taskInfo.assignee)!;
+  const user = userList[taskInfo.assignee!];
   return (
     <StyledTaskCard onDoubleClick={onDoubleClickTask} onMouseDown={onMouseDownTask}>
       <Title titleStyle={'normal'}>{taskInfo.content}</Title>
@@ -26,11 +26,11 @@ const TaskCard: React.FC<IProps> = ({ taskInfo, onDoubleClickTask, onMouseDownTa
           </TaskInfo>
           <TaskInfo title={'중요도: '} content={taskInfo.priority!}></TaskInfo>
           {taskInfo.labels?.map((labelId) => (
-            <LabelIcon key={labelId} label={labelList.find((l) => l.id === labelId)!}></LabelIcon>
+            <LabelIcon key={labelId} label={labelList[labelId!]}></LabelIcon>
           ))}
         </StyledCardInfoLeft>
         <StyledCardInfoRight>
-          <TaskInfo title={'스프린트: '} content={taskInfo.sprint ? sprintList.find((s) => s.id === taskInfo.sprint)!.name : ''}></TaskInfo>
+          <TaskInfo title={'스프린트: '} content={taskInfo.sprint ? sprintList[taskInfo.sprint].name : ''}></TaskInfo>
           <TaskInfo title={'예상 소요 시간: '} content={taskInfo.estimatedTime ?? ''}>
             {taskInfo.estimatedTime ?? (
               <SmallText color={'black'} margin={'0 0 0 3px'}>

--- a/client/src/components/organisms/TaskCard/index.tsx
+++ b/client/src/components/organisms/TaskCard/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
-import { queryUserListState } from 'recoil/user-list';
+import { userListState } from 'recoil/project';
 import { IMindNode } from 'types/mindmap';
 import { Title, SmallText, UserIcon, Wrapper } from 'components/atoms';
 import { TaskInfo } from 'components/molecules';
@@ -12,8 +12,8 @@ interface IProps {
 }
 
 const TaskCard: React.FC<IProps> = ({ taskInfo, onDoubleClickTask, onMouseDownTask }) => {
-  const userList = useRecoilValue(queryUserListState)!;
-  const user = userList[taskInfo.assignee!];
+  const userList = useRecoilValue(userListState)!;
+  const user = userList.find((users) => users.id === taskInfo.assignee)!;
   return (
     <StyledTaskCard onDoubleClick={onDoubleClickTask} onMouseDown={onMouseDownTask}>
       <Title titleStyle={'normal'}>{taskInfo.content}</Title>

--- a/client/src/components/organisms/TaskCard/index.tsx
+++ b/client/src/components/organisms/TaskCard/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
-import { userListState } from 'recoil/project';
+import { labelListState, sprintListState, userListState } from 'recoil/project';
 import { IMindNode } from 'types/mindmap';
 import { Title, SmallText, UserIcon, Wrapper } from 'components/atoms';
-import { TaskInfo } from 'components/molecules';
+import { LabelIcon, TaskInfo } from 'components/molecules';
 import { StyledTaskCard, StyledCardInfoLeft, StyledCardInfoRight } from './style';
 interface IProps {
   taskInfo: IMindNode;
@@ -13,31 +13,30 @@ interface IProps {
 
 const TaskCard: React.FC<IProps> = ({ taskInfo, onDoubleClickTask, onMouseDownTask }) => {
   const userList = useRecoilValue(userListState)!;
+  const sprintList = useRecoilValue(sprintListState)!;
+  const labelList = useRecoilValue(labelListState)!;
   const user = userList.find((users) => users.id === taskInfo.assignee)!;
   return (
     <StyledTaskCard onDoubleClick={onDoubleClickTask} onMouseDown={onMouseDownTask}>
       <Title titleStyle={'normal'}>{taskInfo.content}</Title>
       <Wrapper flex={'row'}>
         <StyledCardInfoLeft>
-          <TaskInfo title={'담당자: '} content={user.name}>
-            <UserIcon user={user} />
+          <TaskInfo title={'담당자: '} content={user ? user.name : ''}>
+            {user !== undefined ?? <UserIcon user={user} />}
           </TaskInfo>
           <TaskInfo title={'중요도: '} content={taskInfo.priority!}></TaskInfo>
-          <TaskInfo
-            title={'라벨: '}
-            content={
-              taskInfo.labels!.reduce((pre, e) => {
-                return pre + ', ' + e;
-              }, '')!
-            }
-          ></TaskInfo>
+          {taskInfo.labels?.map((labelId) => (
+            <LabelIcon key={labelId} label={labelList.find((l) => l.id === labelId)!}></LabelIcon>
+          ))}
         </StyledCardInfoLeft>
         <StyledCardInfoRight>
-          <TaskInfo title={'스프린트: '} content={taskInfo.sprint as unknown as string}></TaskInfo>
-          <TaskInfo title={'예상 소요 시간: '} content={taskInfo.estimatedTime as unknown as string}>
-            <SmallText color={'black'} margin={'0 0 0 3px'}>
-              {'시간 '}
-            </SmallText>
+          <TaskInfo title={'스프린트: '} content={taskInfo.sprint ? sprintList.find((s) => s.id === taskInfo.sprint)!.name : ''}></TaskInfo>
+          <TaskInfo title={'예상 소요 시간: '} content={taskInfo.estimatedTime ?? ''}>
+            {taskInfo.estimatedTime ?? (
+              <SmallText color={'black'} margin={'0 0 0 3px'}>
+                {'시간 '}
+              </SmallText>
+            )}
           </TaskInfo>
           <TaskInfo title={'마감 시간: '} content={taskInfo.dueDate!}></TaskInfo>
         </StyledCardInfoRight>

--- a/client/src/components/organisms/TaskCard/index.tsx
+++ b/client/src/components/organisms/TaskCard/index.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { queryUserListState } from 'recoil/user-list';
+import { IMindNode } from 'types/mindmap';
+import { Title, SmallText, UserIcon, Wrapper } from 'components/atoms';
+import { TaskInfo } from 'components/molecules';
+import { StyledTaskCard, StyledCardInfoLeft, StyledCardInfoRight } from './style';
+interface IProps {
+  taskInfo: IMindNode;
+  onDoubleClickTask: (event: React.MouseEvent<HTMLElement>) => void;
+  onMouseDownTask: (event: React.MouseEvent<HTMLElement>) => void;
+}
+
+const TaskCard: React.FC<IProps> = ({ taskInfo, onDoubleClickTask, onMouseDownTask }) => {
+  const userList = useRecoilValue(queryUserListState)!;
+  const user = userList[taskInfo.assignee!];
+  return (
+    <StyledTaskCard onDoubleClick={onDoubleClickTask} onMouseDown={onMouseDownTask}>
+      <Title titleStyle={'normal'}>{taskInfo.content}</Title>
+      <Wrapper flex={'row'}>
+        <StyledCardInfoLeft>
+          <TaskInfo title={'담당자: '} content={user.name}>
+            <UserIcon user={user} />
+          </TaskInfo>
+          <TaskInfo title={'중요도: '} content={taskInfo.priority!}></TaskInfo>
+          <TaskInfo
+            title={'라벨: '}
+            content={
+              taskInfo.labels!.reduce((pre, e) => {
+                return pre + ', ' + e;
+              }, '')!
+            }
+          ></TaskInfo>
+        </StyledCardInfoLeft>
+        <StyledCardInfoRight>
+          <TaskInfo title={'스프린트: '} content={taskInfo.sprint as unknown as string}></TaskInfo>
+          <TaskInfo title={'예상 소요 시간: '} content={taskInfo.estimatedTime as unknown as string}>
+            <SmallText color={'black'} margin={'0 0 0 3px'}>
+              {'시간 '}
+            </SmallText>
+          </TaskInfo>
+          <TaskInfo title={'마감 시간: '} content={taskInfo.dueDate!}></TaskInfo>
+        </StyledCardInfoRight>
+      </Wrapper>
+    </StyledTaskCard>
+  );
+};
+
+export default TaskCard;

--- a/client/src/components/organisms/TaskCard/index.tsx
+++ b/client/src/components/organisms/TaskCard/index.tsx
@@ -15,14 +15,14 @@ const TaskCard: React.FC<IProps> = ({ taskInfo, onDoubleClickTask, onMouseDownTa
   const userList = useRecoilValue(userListState)!;
   const sprintList = useRecoilValue(sprintListState)!;
   const labelList = useRecoilValue(labelListState)!;
-  const user = userList[taskInfo.assignee!];
+  const user = taskInfo.assignee ? userList[taskInfo.assignee] : undefined;
   return (
     <StyledTaskCard onDoubleClick={onDoubleClickTask} onMouseDown={onMouseDownTask}>
       <Title titleStyle={'normal'}>{taskInfo.content}</Title>
       <Wrapper flex={'row'}>
         <StyledCardInfoLeft>
           <TaskInfo title={'담당자: '} content={user ? user.name : ''}>
-            {user !== undefined ?? <UserIcon user={user} />}
+            {user !== undefined ? <UserIcon user={user} /> : ''}
           </TaskInfo>
           <TaskInfo title={'중요도: '} content={taskInfo.priority!}></TaskInfo>
           {taskInfo.labels?.map((labelId) => (

--- a/client/src/components/organisms/TaskCard/style.ts
+++ b/client/src/components/organisms/TaskCard/style.ts
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+export const StyledTaskCard = styled.div`
+  ${({ theme }) => theme.flex.column}
+  margin: 10px 0px;
+  padding: ${({ theme }) => theme.padding.xlarge};
+  margin: ${({ theme }) => theme.margin.xxxlarge};
+  margin-top: 0;
+  margin-bottom: 10px;
+  background-color: ${({ theme }) => theme.color.white};
+  border-radius: 8px;
+  -webkit-box-shadow: 1px 4px 11px -1px rgba(0, 0, 0, 0.56);
+  box-shadow: 1px 4px 11px -1px rgba(0, 0, 0, 0.56);
+`;
+
+export const StyledCardInfoLeft = styled.div`
+  ${({ theme }) => theme.flex.column}
+  margin: 0 auto 0 0;
+`;
+export const StyledCardInfoRight = styled.div`
+  ${({ theme }) => theme.flex.column}
+  margin: 0 auto;
+  @media screen and (max-width: 1200px) {
+    display: none;
+  }
+`;

--- a/client/src/components/organisms/index.tsx
+++ b/client/src/components/organisms/index.tsx
@@ -12,3 +12,4 @@ export { default as Header } from 'components/organisms/Header';
 export { default as HistoryBar } from 'components/organisms/HistoryBar';
 export { default as UserList } from 'components/organisms/UserList';
 export { default as HistoryBackground } from 'components/organisms/HistoryBackground';
+export { default as TaskCard } from 'components/organisms/TaskCard';

--- a/client/src/components/templates/CommonLayout/index.tsx
+++ b/client/src/components/templates/CommonLayout/index.tsx
@@ -1,19 +1,13 @@
-import { Suspense, useState } from 'react';
+import { useState } from 'react';
 import { filterIcon } from 'img';
 import { BoxButton } from 'components/atoms';
 import { NodeDetailWrapper, UserList, Header, FilterPopup } from 'components/organisms';
 import useSocketSetup from 'hooks/useSocketSetup';
 
-import { Spinner } from 'components/molecules';
-
 import { LeftInfo, RightInfo, Template } from './style';
 import useProject from 'hooks/useProject';
 
-interface IProps {
-  children?: React.ReactNode;
-}
-
-const CommonLayout: React.FC<IProps> = ({ children }) => {
+const CommonLayout: React.FC = ({ children }) => {
   useSocketSetup();
   const [DisplayFilter, setDisplayFilter] = useState(false);
   const handleFilterButton = () => setDisplayFilter(true);
@@ -23,22 +17,21 @@ const CommonLayout: React.FC<IProps> = ({ children }) => {
   return (
     <Template>
       <Header />
-      <Suspense fallback={<Spinner />}>
-        <LeftInfo>
-          <UserList />
-        </LeftInfo>
-        <RightInfo>
-          {DisplayFilter ? (
-            <FilterPopup onClose={handleClickFilterPopupClose} />
-          ) : (
-            <BoxButton onClick={handleFilterButton} btnStyle={'normal'} margin='1rem 0 0 auto'>
-              <img src={filterIcon} alt='필터링 버튼'></img>
-              {'필터링'}
-            </BoxButton>
-          )}
-          <NodeDetailWrapper />
-        </RightInfo>
-      </Suspense>
+
+      <LeftInfo>
+        <UserList />
+      </LeftInfo>
+      <RightInfo>
+        {DisplayFilter ? (
+          <FilterPopup onClose={handleClickFilterPopupClose} />
+        ) : (
+          <BoxButton onClick={handleFilterButton} btnStyle={'normal'} margin='1rem 0 0 auto'>
+            <img src={filterIcon} alt='필터링 버튼'></img>
+            {'필터링'}
+          </BoxButton>
+        )}
+        <NodeDetailWrapper />
+      </RightInfo>
       {children}
     </Template>
   );

--- a/client/src/components/templates/CommonLayout/style.ts
+++ b/client/src/components/templates/CommonLayout/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const Template = styled.div`
-  position: fixed;
+  position: relative;
   width: 100%;
   height: 100vh;
   background-color: ${({ theme }) => theme.color.bgWhite};

--- a/client/src/components/templates/CommonLayout/style.ts
+++ b/client/src/components/templates/CommonLayout/style.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 
 export const Template = styled.div`
-  position: relative;
+  position: fixed;
   width: 100%;
   height: 100vh;
   background-color: ${({ theme }) => theme.color.bgWhite};

--- a/client/src/components/templates/TaskCardContainer/index.tsx
+++ b/client/src/components/templates/TaskCardContainer/index.tsx
@@ -6,6 +6,8 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { selectedNodeIdState } from 'recoil/node';
 import { mindmapState } from 'recoil/mindmap';
 import useHistoryEmitter from 'hooks/useHistoryEmitter';
+// import useToast from 'hooks/useToast';
+// import { userState } from 'recoil/user';
 
 const StyledTaskCardContainer = styled.div`
   ${(props) => props.theme.flex.column}
@@ -41,6 +43,8 @@ const TaskCardContainer: React.FC<IProps> = ({ taskList, status }) => {
   const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
   const { mindNodes } = useRecoilValue(mindmapState);
   const { updateTaskInformation } = useHistoryEmitter();
+  // const { showMessage } = useToast();
+  // const { id } = useRecoilValue(userState);
   const handleOnDoubleClickTask = (nodeId: number) => {
     setSelectedNodeId(nodeId);
   };
@@ -86,6 +90,10 @@ const TaskCardContainer: React.FC<IProps> = ({ taskList, status }) => {
   };
   const drag = (e: React.MouseEvent<HTMLElement>, currentTarget: HTMLElement, nodeId: number) => {
     if (e.buttons !== 1) return;
+    // if (id !== mindNodes.get(nodeId)?.assignee) {
+    //   showMessage('자신에게 할당된 Task만 이동할 수 있습니다.');
+    //   return;
+    // }
     const clone = currentTarget.cloneNode(true) as HTMLElement;
     clone.style.position = 'absolute';
     clone.style.zIndex = '1000';

--- a/client/src/components/templates/TaskCardContainer/index.tsx
+++ b/client/src/components/templates/TaskCardContainer/index.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { IMindNode } from 'types/mindmap';
+import { TaskCard } from 'components/organisms';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { selectedNodeIdState } from 'recoil/node';
+import { getNextMapState, mindmapState } from 'recoil/mindmap';
+
+const StyledTaskCardContainer = styled.div`
+  ${(props) => props.theme.flex.column}
+  margin: 90px 10px 0 10px;
+  width: 30vw;
+  min-width: 300px;
+  height: 88vh;
+  overflow-y: scroll;
+  background-color: ${({ theme }) => theme.color.primary1};
+  border-radius: 8px;
+  -webkit-box-shadow: 1px 4px 11px -1px rgba(0, 0, 0, 0.4);
+  box-shadow: 1px 4px 11px -1px rgba(0, 0, 0, 0.4);
+`;
+const StyledTitle = styled.div`
+  position: sticky;
+  align-self: flex-start;
+  text-align: center;
+  top: 0%;
+  width: 30vw;
+  padding: 2vh;
+  background-color: ${({ theme }) => theme.color.primary1};
+  font-size: ${({ theme }) => theme.fontSize.title};
+  font-weight: bold;
+  color: ${({ theme }) => theme.color.white};
+`;
+
+interface IProps {
+  taskList: IMindNode[];
+  status: 'To Do' | 'In Progress' | 'Done';
+}
+
+const TaskCardContainer: React.FC<IProps> = ({ taskList, status }) => {
+  const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
+  const setMindmapData = useSetRecoilState(mindmapState);
+  const { mindNodes } = useRecoilValue(mindmapState);
+  const handleOnDoubleClickTask = (nodeId: number) => {
+    setSelectedNodeId(nodeId);
+  };
+  let clicks = 0;
+  let dragTimeOut: NodeJS.Timeout;
+  const handleMouseDown = (e: React.MouseEvent<HTMLElement>, nodeId: number) => {
+    e.preventDefault();
+    const { currentTarget } = e;
+    clicks++;
+    if (clicks === 1) {
+      dragTimeOut = setTimeout(() => {
+        clicks = 0;
+        drag(e, currentTarget, nodeId);
+      }, 200);
+    }
+    if (clicks === 2) {
+      clearTimeout(dragTimeOut);
+      clicks = 0;
+    }
+  };
+  const drag = (e: React.MouseEvent<HTMLElement>, currentTarget: HTMLElement, nodeId: number) => {
+    if (e.buttons !== 1) return;
+    const clone = currentTarget.cloneNode(true) as HTMLElement;
+    clone.style.position = 'absolute';
+    clone.style.zIndex = '1000';
+    document.body.append(clone);
+    const moveAt = (pageX: number, pageY: number) => {
+      clone.style.left = pageX - clone.offsetWidth / 2 + 'px';
+      clone.style.top = pageY - clone.offsetHeight / 2 + 'px';
+    };
+    const onMouseMove = (event: MouseEvent) => {
+      moveAt(event.pageX, event.pageY);
+    };
+    moveAt(e.pageX, e.pageY);
+    document.addEventListener('mousemove', onMouseMove);
+    clone.onmouseup = (event: MouseEvent) => {
+      clone.style.display = 'none';
+      const elemBelow = document.elementFromPoint(event.clientX, event.clientY)! as HTMLElement;
+      const container = elemBelow.closest('.CardContainer')! as HTMLDivElement;
+      const currentTask = mindNodes.get(nodeId)!;
+      if (currentTask.status !== container.dataset.status) {
+        mindNodes.set(nodeId, { ...currentTask, status: container.dataset.status as 'To Do' | 'In Progress' | 'Done' });
+        const newMapData = getNextMapState({ rootId: 0, mindNodes });
+        setMindmapData(newMapData);
+      }
+      document.removeEventListener('mousemove', onMouseMove);
+      clone.remove();
+    };
+  };
+
+  return (
+    <StyledTaskCardContainer className='CardContainer' data-status={status}>
+      <StyledTitle>{status}</StyledTitle>
+      {taskList.map((task) => (
+        <TaskCard
+          key={task.nodeId}
+          taskInfo={task}
+          onDoubleClickTask={() => handleOnDoubleClickTask(task.nodeId)}
+          onMouseDownTask={(e: React.MouseEvent<HTMLElement>) => handleMouseDown(e, task.nodeId)}
+        ></TaskCard>
+      ))}
+    </StyledTaskCardContainer>
+  );
+};
+
+export default TaskCardContainer;

--- a/client/src/components/templates/TaskCardContainer/index.tsx
+++ b/client/src/components/templates/TaskCardContainer/index.tsx
@@ -4,7 +4,8 @@ import { IMindNode } from 'types/mindmap';
 import { TaskCard } from 'components/organisms';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { selectedNodeIdState } from 'recoil/node';
-import { getNextMapState, mindmapState } from 'recoil/mindmap';
+import { mindmapState } from 'recoil/mindmap';
+import useHistoryEmitter from 'hooks/useHistoryEmitter';
 
 const StyledTaskCardContainer = styled.div`
   ${(props) => props.theme.flex.column}
@@ -38,8 +39,8 @@ interface IProps {
 
 const TaskCardContainer: React.FC<IProps> = ({ taskList, status }) => {
   const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
-  const setMindmapData = useSetRecoilState(mindmapState);
   const { mindNodes } = useRecoilValue(mindmapState);
+  const { updateTaskInformation } = useHistoryEmitter();
   const handleOnDoubleClickTask = (nodeId: number) => {
     setSelectedNodeId(nodeId);
   };
@@ -60,34 +61,39 @@ const TaskCardContainer: React.FC<IProps> = ({ taskList, status }) => {
       clicks = 0;
     }
   };
+  const moveAt = (clone: HTMLElement, pageX: number, pageY: number) => {
+    clone.style.left = pageX - clone.offsetWidth / 2 + 'px';
+    clone.style.top = pageY - clone.offsetHeight / 2 + 'px';
+  };
+  const onMouseMove = (clone: HTMLElement, event: MouseEvent) => {
+    moveAt(clone, event.pageX, event.pageY);
+  };
+  const onMouseUp = (clone: HTMLElement, nodeId: number, mouseMove: (event: MouseEvent) => void, event: MouseEvent) => {
+    clone.style.display = 'none';
+    const elemBelow = document.elementFromPoint(event.clientX, event.clientY)! as HTMLElement;
+    const container = elemBelow.closest('.CardContainer')! as HTMLDivElement;
+    const currentTask = mindNodes.get(nodeId)!;
+    if (currentTask.status !== container.dataset.status) {
+      updateTaskInformation({
+        nodeFrom: nodeId,
+        nodeTo: nodeId,
+        dataFrom: { changed: { status: currentTask.status } },
+        dataTo: { changed: { status: container.dataset.status as 'To Do' | 'In Progress' | 'Done' } },
+      });
+    }
+    document.removeEventListener('mousemove', mouseMove);
+    clone.remove();
+  };
   const drag = (e: React.MouseEvent<HTMLElement>, currentTarget: HTMLElement, nodeId: number) => {
     if (e.buttons !== 1) return;
     const clone = currentTarget.cloneNode(true) as HTMLElement;
     clone.style.position = 'absolute';
     clone.style.zIndex = '1000';
     document.body.append(clone);
-    const moveAt = (pageX: number, pageY: number) => {
-      clone.style.left = pageX - clone.offsetWidth / 2 + 'px';
-      clone.style.top = pageY - clone.offsetHeight / 2 + 'px';
-    };
-    const onMouseMove = (event: MouseEvent) => {
-      moveAt(event.pageX, event.pageY);
-    };
-    moveAt(e.pageX, e.pageY);
-    document.addEventListener('mousemove', onMouseMove);
-    clone.onmouseup = (event: MouseEvent) => {
-      clone.style.display = 'none';
-      const elemBelow = document.elementFromPoint(event.clientX, event.clientY)! as HTMLElement;
-      const container = elemBelow.closest('.CardContainer')! as HTMLDivElement;
-      const currentTask = mindNodes.get(nodeId)!;
-      if (currentTask.status !== container.dataset.status) {
-        mindNodes.set(nodeId, { ...currentTask, status: container.dataset.status as 'To Do' | 'In Progress' | 'Done' });
-        const newMapData = getNextMapState({ rootId: 0, mindNodes });
-        setMindmapData(newMapData);
-      }
-      document.removeEventListener('mousemove', onMouseMove);
-      clone.remove();
-    };
+    moveAt(clone, e.pageX, e.pageY);
+    const mouseMove = (event: MouseEvent) => onMouseMove(clone, event);
+    document.addEventListener('mousemove', mouseMove);
+    clone.addEventListener('mouseup', (event: MouseEvent) => onMouseUp(clone, nodeId, mouseMove, event));
   };
 
   return (

--- a/client/src/components/templates/index.tsx
+++ b/client/src/components/templates/index.tsx
@@ -1,3 +1,4 @@
 export { default as ProjectCardContainer } from 'components/templates/ProjectCardContainer';
 export { default as NewProjectModalWrapper } from 'components/templates/NewProjectModalWrapper';
 export { default as MindmapTemplate } from 'components/templates/MindmapTemplate';
+export { default as TaskCardContainer } from 'components/templates/TaskCardContainer';

--- a/client/src/pages/Kanban/index.tsx
+++ b/client/src/pages/Kanban/index.tsx
@@ -6,7 +6,7 @@ import { taskState } from 'recoil/mindmap';
 
 const Kanban = () => {
   const taskNodes = useRecoilValue(taskState);
-  const toDoTasks = taskNodes.filter((task) => task.status === 'To Do');
+  const toDoTasks = taskNodes.filter((task) => !task.status || task.status === 'To Do');
   const inProgressTasks = taskNodes.filter((task) => task.status === 'In Progress');
   const doneTasks = taskNodes.filter((task) => task.status === 'Done');
   return (

--- a/client/src/pages/Kanban/index.tsx
+++ b/client/src/pages/Kanban/index.tsx
@@ -1,9 +1,21 @@
 import CommonLayout from 'components/templates/CommonLayout';
+import { TaskCardContainer } from 'components/templates';
+import { Wrapper } from 'components/atoms';
+import { useRecoilValue } from 'recoil';
+import { taskState } from 'recoil/mindmap';
 
 const Kanban = () => {
+  const taskNodes = useRecoilValue(taskState);
+  const toDoTasks = taskNodes.filter((task) => task.status === 'To Do');
+  const inProgressTasks = taskNodes.filter((task) => task.status === 'In Progress');
+  const doneTasks = taskNodes.filter((task) => task.status === 'Done');
   return (
     <CommonLayout>
-      <h1>칸반페이지</h1>
+      <Wrapper flex={'center'}>
+        <TaskCardContainer status={'To Do'} taskList={toDoTasks} />
+        <TaskCardContainer status={'In Progress'} taskList={inProgressTasks} />
+        <TaskCardContainer status={'Done'} taskList={doneTasks} />
+      </Wrapper>
     </CommonLayout>
   );
 };

--- a/client/src/recoil/mindmap/index.ts
+++ b/client/src/recoil/mindmap/index.ts
@@ -25,3 +25,11 @@ export const mindmapNodesState = selector({
     return mindNodes;
   },
 });
+
+export const taskState = selector({
+  key: 'taskState',
+  get: ({ get }) => {
+    const { mindNodes } = get(mindmapState);
+    return Array.from(mindNodes.values()).filter((node) => node.level === 'TASK');
+  },
+});

--- a/client/src/styles/common.ts
+++ b/client/src/styles/common.ts
@@ -43,7 +43,7 @@ const fontSize: { [key in TFontSize]: string } = {
   xlarge: calcRem(20),
   xxlarge: calcRem(22),
   xxxlarge: calcRem(24),
-  title: calcRem(50),
+  title: calcRem(36),
 };
 
 const padding: { [key in TSize]: string } = {

--- a/client/src/types/event.ts
+++ b/client/src/types/event.ts
@@ -32,7 +32,7 @@ export type TUpdateNodeContent = {
   content: string;
 };
 export type TTask = {
-  assignee?: number;
+  assignee?: string;
   labels?: number[];
   priority?: string;
   dueDate?: string;

--- a/client/src/types/event.ts
+++ b/client/src/types/event.ts
@@ -37,6 +37,7 @@ export type TTask = {
   priority?: string;
   dueDate?: string;
   estimatedTime?: string;
+  status?: 'To Do' | 'In Progress' | 'Done';
   finishedTime?: string;
   sprint?: number;
 };

--- a/server/src/database/entities/Task.ts
+++ b/server/src/database/entities/Task.ts
@@ -22,6 +22,9 @@ export class Task {
   @Column({ nullable: true })
   estimatedTime: string;
 
+  @Column({ default: 'To Do' })
+  status: string;
+
   @Column({ nullable: true })
   finishedTime: string;
 

--- a/server/src/database/entities/Task.ts
+++ b/server/src/database/entities/Task.ts
@@ -28,7 +28,7 @@ export class Task {
   @Column({ nullable: true })
   finishedTime: string;
 
-  @ManyToOne(() => Sprint, (sprints) => sprints.id, { cascade: true })
+  @ManyToOne(() => Sprint, (sprints) => sprints.id, { onDelete: 'SET NULL' })
   sprint: Sprint;
 
   @ManyToMany(() => Label, (labels) => labels.id, { cascade: true })

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -31,7 +31,7 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
     UPDATE_NODE_PARENT: ({ nodeFrom, nodeTo, dataTo }) => {
       const { nodeId, nodeParentType } = dataTo as eventType.TUpdateNodeParent;
       updateNodeParent(nodeFrom, nodeTo, nodeId);
-      if (nodeParentType !== 'Story') deleteTask(nodeId);
+      if (nodeParentType !== 'STORY') deleteTask(nodeId);
       return;
     },
     UPDATE_NODE_SIBLING: ({ dataTo }) => {

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -2,7 +2,7 @@ export type TDeleteNodeData = {
   nodeId: number;
   content: string;
   index: number;
-  status?: string;
+  status?: 'To Do' | 'In Progress' | 'Done';
   posX?: string;
   posY?: string;
   assignee?: number;
@@ -33,6 +33,7 @@ export type TTask = {
   priority?: string;
   dueDate?: string;
   estimatedTime?: string;
+  status?: 'To Do' | 'In Progress' | 'Done';
   finishedTime?: string;
   sprint?: number;
 };

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -18,7 +18,7 @@ export type TMoveNodeData = {
 };
 export type TUpdateNodeParent = {
   nodeId: number;
-  nodeParentType: 'Project' | 'Epic' | 'Story';
+  nodeParentType: 'PROJECT' | 'EPIC' | 'STORY';
 };
 export type TUpdateNodeSibling = {
   parentId: number;


### PR DESCRIPTION
## 📑 제목
프로젝트 칸반보드 페이지 UI, 작업상태 변경
## 📎 관련 이슈
- #103 
- #105 
## ✔️ 셀프 체크리스트
- [x] 프로젝트의 Task들을 칸반보드 형태로 표시한다.
- [x] 각 Task는 카드 형태이다.
- [x] Task 상세정보창 활성화
- [x] Task 카드 드래그 앤 드롭
- [x] 작업 상태 변경
- [x] 유저에게 할당 된 Task 카드만 이동 가능 
## 💬 작업 내용
- 칸반보드 페이지 필터링 제외한 작업
## 🚧 PR 특이 사항
- LabelIcon 같은 건 테스트 안 해봤음
- 일단 스프린트랑 라벨 등 기타 task 상태 연동 필요
- Recoil/user 가 로그인 한 유저 상태라고 생각했는데 맞는지?
- pr 단위 더 커지기 전에 보냄
## 🕰 실제 소요 시간
11h