### PR TITLE
 노드 정보 수정 반영

### DIFF
--- a/client/src/components/atoms/ModalOverlay/index.tsx
+++ b/client/src/components/atoms/ModalOverlay/index.tsx
@@ -15,7 +15,7 @@ const StyledModalOverlay = styled.div<IStyledProps>`
   bottom: 0;
   right: 0;
   background-color: rgba(0, 0, 0, 0.6);
-  z-index: 0;
+  z-index: 2;
 `;
 
 export default StyledModalOverlay;

--- a/client/src/components/atoms/Toast/index.tsx
+++ b/client/src/components/atoms/Toast/index.tsx
@@ -13,6 +13,7 @@ const StyledToastContainer = styled.div`
   bottom: 10%;
   left: 50%;
   transform: translateX(-50%);
+  z-index: 4;
 `;
 
 const StyledToast = styled.div<IStyledToast>`

--- a/client/src/components/molecules/Dropdown/index.tsx
+++ b/client/src/components/molecules/Dropdown/index.tsx
@@ -2,24 +2,24 @@ import React, { useRef, useState } from 'react';
 import { DropdownList, StyledInput, TStyle, Wrapper } from './style';
 
 interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
-  onValueChange?: (arg: string) => void;
+  onValueChange?: (arg: string | number) => void;
   dropdownStyle?: TStyle;
-  items?: string[];
+  items?: Record<string | number, string>;
   margin?: string;
 }
 
-const Dropdown: React.FC<IProps> = ({ onValueChange, dropdownStyle = 'normal', items = [], margin = '0', ...props }) => {
+const Dropdown: React.FC<IProps> = ({ onValueChange, dropdownStyle = 'normal', items = {}, margin = '0', ...props }) => {
   const activatorRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const [isOpen, setIsOpen] = useState(false);
 
   const handleClickDropdown = () => setIsOpen(!isOpen);
-  const handleClickItem = (value: string) => {
+  const handleClickItem = (id: string | number) => {
     if (activatorRef.current) {
-      activatorRef.current.value = value;
+      activatorRef.current.value = items[id];
     }
     if (onValueChange) {
-      onValueChange(value);
+      onValueChange(id);
     }
     setIsOpen(false);
   };
@@ -46,9 +46,9 @@ const Dropdown: React.FC<IProps> = ({ onValueChange, dropdownStyle = 'normal', i
     <Wrapper margin={margin}>
       <StyledInput dropdownStyle={dropdownStyle} onClick={handleClickDropdown} ref={activatorRef} {...props} readOnly={true} />
       <DropdownList dropdownStyle={dropdownStyle} visible={isOpen} ref={listRef}>
-        {items.map((item, idx) => (
-          <li key={idx} onClick={() => handleClickItem(item)}>
-            {item}
+        {Object.keys(items).map((id) => (
+          <li key={id} onClick={() => handleClickItem(id)}>
+            {items[id]}
           </li>
         ))}
       </DropdownList>

--- a/client/src/components/molecules/PopupLayout/style.ts
+++ b/client/src/components/molecules/PopupLayout/style.ts
@@ -20,6 +20,7 @@ const styleOptions: { [key in TStyle]: string } = {
       width: 25rem;
       padding: 0.5rem  1rem  1rem 1rem;
       font-size: ${common.fontSize.normal};
+      z-index: 3;
     `,
 };
 

--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -16,7 +16,7 @@ interface ITreeProps {
   parentId?: number;
 }
 
-const TEMP_NODE_ID = -1;
+const TEMP_NODE_ID = -2;
 
 const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId }) => {
   const { rootId, mindNodes } = mindmapData;

--- a/client/src/components/organisms/MindmapBtnWrapper/index.tsx
+++ b/client/src/components/organisms/MindmapBtnWrapper/index.tsx
@@ -25,7 +25,6 @@ const createTempNode = ({ mindmapData, selectedNodeId }: ITempNodeParams) => {
   parentNode!.children = [...parentNode!.children!, TEMP_NODE_ID];
   mindNodes.set(parentNode!.nodeId!, parentNode!);
   mindNodes.set(TEMP_NODE_ID, tempNode);
-  console.log(parentNode);
 
   const newMapState = getNextMapState({ mindNodes, rootId });
 

--- a/client/src/components/organisms/MindmapBtnWrapper/index.tsx
+++ b/client/src/components/organisms/MindmapBtnWrapper/index.tsx
@@ -14,7 +14,7 @@ interface ITempNodeParams {
   selectedNodeId: number | null;
 }
 
-const TEMP_NODE_ID = -1;
+const TEMP_NODE_ID = -2;
 
 const createTempNode = ({ mindmapData, selectedNodeId }: ITempNodeParams) => {
   const { rootId, mindNodes } = mindmapData;
@@ -25,6 +25,7 @@ const createTempNode = ({ mindmapData, selectedNodeId }: ITempNodeParams) => {
   parentNode!.children = [...parentNode!.children!, TEMP_NODE_ID];
   mindNodes.set(parentNode!.nodeId!, parentNode!);
   mindNodes.set(TEMP_NODE_ID, tempNode);
+  console.log(parentNode);
 
   const newMapState = getNextMapState({ mindNodes, rootId });
 

--- a/client/src/components/organisms/NodeDetailWrapper/index.tsx
+++ b/client/src/components/organisms/NodeDetailWrapper/index.tsx
@@ -10,6 +10,7 @@ import useToast from 'hooks/useToast';
 import useHistoryEmitter from 'hooks/useHistoryEmitter';
 import { IMindNode } from 'types/mindmap';
 import { sprintListState, userListState } from 'recoil/project';
+import { TTask } from 'types/event';
 
 export const NodeDetailWrapper = () => {
   const priorityList = useRecoilValue(priorityListState);
@@ -25,10 +26,10 @@ export const NodeDetailWrapper = () => {
   priorityList.forEach((priority) => (priorityDropdownItem[priority] = priority));
 
   const sprintDropdownItem: Record<number, string> = {};
-  sprintList.forEach((sprint) => (sprintDropdownItem[sprint.id] = sprint.name));
+  Object.values(sprintList).forEach((sprint) => (sprintDropdownItem[sprint.id] = sprint.name));
 
   const uerDropdownItem: Record<string, string> = {};
-  userList.forEach((user) => (uerDropdownItem[user.id] = user.name));
+  Object.values(userList).forEach((user) => (uerDropdownItem[user.id] = user.name));
 
   const handleCloseButton = () => setSelectedNodeId(null);
 
@@ -43,8 +44,8 @@ export const NodeDetailWrapper = () => {
     showMessage(`${info} ${e.target.value}로 변경.`);
   };
 
-  const handleChangeNodeDetail = (info: keyof IMindNode) => (value: number | string) => {
-    const prevValue = selectedNode?.[info];
+  const handleChangeNodeDetail = (info: keyof TTask) => (value: number | string) => {
+    const prevValue = selectedNode![info];
     if (value === prevValue) {
       return;
     }
@@ -53,7 +54,6 @@ export const NodeDetailWrapper = () => {
       dataFrom: { changed: { [info]: prevValue } },
       dataTo: { changed: { [info]: value } },
     });
-    showMessage(`${info} ${value}로 변경.`);
   };
 
   const handleBlurDueDate = ({ target }: React.FocusEvent<HTMLInputElement>) => {
@@ -85,7 +85,7 @@ export const NodeDetailWrapper = () => {
       return;
     }
     const newEstimatedTime = target.value + '시간';
-    const prevValue = selectedNode?.estimatedTime;
+    const prevValue = selectedNode!.estimatedTime;
     if (newEstimatedTime !== prevValue) {
       updateTaskInformation({
         nodeFrom: selectedNode!.nodeId,
@@ -102,55 +102,59 @@ export const NodeDetailWrapper = () => {
       <PopupItemLayout title={'내용'}>
         <Input defaultValue={selectedNode.content} onBlur={handleBlurNodeDetail('content')} inputStyle='gray' margin='0.2rem 0 0 0'></Input>
       </PopupItemLayout>
-      <PopupItemLayout title={'세부사항'}>
-        <Label label='스프린트' labelStyle='small' ratio={0.5} htmlFor='sprint'>
-          <Dropdown
-            id='sprint'
-            items={sprintDropdownItem}
-            placeholder={selectedNode.sprint ? sprintList[selectedNode.sprint].name : ''}
-            onValueChange={handleChangeNodeDetail('sprint')}
-            dropdownStyle='small'
-          />
-        </Label>
-        <Label label='담당자' labelStyle='small' ratio={0.5} htmlFor='assignee'>
-          <Dropdown
-            id='assignee'
-            items={uerDropdownItem}
-            placeholder={selectedNode.assignee ? userList[selectedNode.assignee].name : ''}
-            onValueChange={handleChangeNodeDetail('assignee')}
-            dropdownStyle='small'
-          />
-        </Label>
-        <Label label='마감 날짜' labelStyle='small' ratio={0.5} htmlFor='dueDate'>
-          <Input
-            id='dueDate'
-            placeholder={selectedNode.dueDate}
-            onFocus={handleFocusAlarm('YYYY-MM-DD 형식으로 입력하세요.')}
-            onBlur={handleBlurDueDate}
-            inputStyle='small'
-            margin='0.1rem 0'
-          />
-        </Label>
-        <Label label='예상 소요 시간' labelStyle='small' ratio={0.5} htmlFor='estimatedTime'>
-          <Input
-            id='estimatedTime'
-            placeholder={selectedNode.estimatedTime}
-            onFocus={handleFocusAlarm('숫자만 입력하세요. 단위는 시(hour)입니다.')}
-            onBlur={handleBlurEstimatedTime}
-            inputStyle='small'
-            margin='0.1rem 0'
-          />
-        </Label>
-        <Label label='중요도' htmlFor='priority' labelStyle='small' ratio={0.5}>
-          <Dropdown
-            id='priority'
-            items={priorityDropdownItem}
-            placeholder={selectedNode.priority}
-            onValueChange={handleChangeNodeDetail('priority')}
-            dropdownStyle='small'
-          />
-        </Label>
-      </PopupItemLayout>
+      {selectedNode.level === 'TASK' ? (
+        <PopupItemLayout title={'세부사항'}>
+          <Label label='스프린트' labelStyle='small' ratio={0.5} htmlFor='sprint'>
+            <Dropdown
+              id='sprint'
+              items={sprintDropdownItem}
+              placeholder={selectedNode.sprintId ? sprintList[selectedNode.sprintId].name : ''}
+              onValueChange={handleChangeNodeDetail('sprintId')}
+              dropdownStyle='small'
+            />
+          </Label>
+          <Label label='담당자' labelStyle='small' ratio={0.5} htmlFor='assignee'>
+            <Dropdown
+              id='assignee'
+              items={uerDropdownItem}
+              placeholder={selectedNode.assigneeId ? userList[selectedNode.assigneeId].name : ''}
+              onValueChange={handleChangeNodeDetail('assigneeId')}
+              dropdownStyle='small'
+            />
+          </Label>
+          <Label label='마감 날짜' labelStyle='small' ratio={0.5} htmlFor='dueDate'>
+            <Input
+              id='dueDate'
+              placeholder={selectedNode.dueDate}
+              onFocus={handleFocusAlarm('YYYY-MM-DD 형식으로 입력하세요.')}
+              onBlur={handleBlurDueDate}
+              inputStyle='small'
+              margin='0.1rem 0'
+            />
+          </Label>
+          <Label label='예상 소요 시간' labelStyle='small' ratio={0.5} htmlFor='estimatedTime'>
+            <Input
+              id='estimatedTime'
+              placeholder={selectedNode.estimatedTime}
+              onFocus={handleFocusAlarm('숫자만 입력하세요. 단위는 시(hour)입니다.')}
+              onBlur={handleBlurEstimatedTime}
+              inputStyle='small'
+              margin='0.1rem 0'
+            />
+          </Label>
+          <Label label='중요도' htmlFor='priority' labelStyle='small' ratio={0.5}>
+            <Dropdown
+              id='priority'
+              items={priorityDropdownItem}
+              placeholder={selectedNode.priority}
+              onValueChange={handleChangeNodeDetail('priority')}
+              dropdownStyle='small'
+            />
+          </Label>
+        </PopupItemLayout>
+      ) : (
+        ''
+      )}
       <PopupItemLayout title={'라벨'}>라벨정보</PopupItemLayout>
     </PopupLayout>
   ) : null;

--- a/client/src/components/organisms/NodeDetailWrapper/index.tsx
+++ b/client/src/components/organisms/NodeDetailWrapper/index.tsx
@@ -49,6 +49,7 @@ export const NodeDetailWrapper = () => {
     if (value === prevValue) {
       return;
     }
+
     updateTaskInformation({
       nodeFrom: selectedNode!.nodeId,
       dataFrom: { changed: { [info]: prevValue } },
@@ -98,9 +99,15 @@ export const NodeDetailWrapper = () => {
   };
 
   return selectedNode ? (
-    <PopupLayout title={selectedNode.backlogId} onClose={handleCloseButton} popupStyle='normal'>
+    <PopupLayout title={String(selectedNode.nodeId)} onClose={handleCloseButton} popupStyle='normal'>
       <PopupItemLayout title={'내용'}>
-        <Input defaultValue={selectedNode.content} onBlur={handleBlurNodeDetail('content')} inputStyle='gray' margin='0.2rem 0 0 0'></Input>
+        <Input
+          key={selectedNode.content}
+          defaultValue={selectedNode.content}
+          onBlur={handleBlurNodeDetail('content')}
+          inputStyle='gray'
+          margin='0.2rem 0 0 0'
+        ></Input>
       </PopupItemLayout>
       {selectedNode.level === 'TASK' ? (
         <PopupItemLayout title={'세부사항'}>

--- a/client/src/components/organisms/TaskCard/index.tsx
+++ b/client/src/components/organisms/TaskCard/index.tsx
@@ -15,7 +15,7 @@ const TaskCard: React.FC<IProps> = ({ taskInfo, onDoubleClickTask, onMouseDownTa
   const userList = useRecoilValue(userListState)!;
   const sprintList = useRecoilValue(sprintListState)!;
   const labelList = useRecoilValue(labelListState)!;
-  const user = taskInfo.assignee ? userList[taskInfo.assignee] : undefined;
+  const user = taskInfo.assigneeId ? userList[taskInfo.assigneeId] : undefined;
   return (
     <StyledTaskCard onDoubleClick={onDoubleClickTask} onMouseDown={onMouseDownTask}>
       <Title titleStyle={'normal'}>{taskInfo.content}</Title>
@@ -30,7 +30,7 @@ const TaskCard: React.FC<IProps> = ({ taskInfo, onDoubleClickTask, onMouseDownTa
           ))}
         </StyledCardInfoLeft>
         <StyledCardInfoRight>
-          <TaskInfo title={'스프린트: '} content={taskInfo.sprint ? sprintList[taskInfo.sprint].name : ''}></TaskInfo>
+          <TaskInfo title={'스프린트: '} content={taskInfo.sprintId ? sprintList[taskInfo.sprintId].name : ''}></TaskInfo>
           <TaskInfo title={'예상 소요 시간: '} content={taskInfo.estimatedTime ?? ''}>
             {taskInfo.estimatedTime ?? (
               <SmallText color={'black'} margin={'0 0 0 3px'}>
@@ -45,4 +45,8 @@ const TaskCard: React.FC<IProps> = ({ taskInfo, onDoubleClickTask, onMouseDownTa
   );
 };
 
-export default TaskCard;
+const isPropsEqual = (prev: IProps, curr: IProps) => JSON.stringify(prev.taskInfo) === JSON.stringify(curr.taskInfo);
+const TaskCardMemo = React.memo(TaskCard, isPropsEqual);
+export default TaskCardMemo;
+
+// export default TaskCard;

--- a/client/src/components/templates/TaskCardContainer/index.tsx
+++ b/client/src/components/templates/TaskCardContainer/index.tsx
@@ -26,7 +26,7 @@ const StyledTitle = styled.div`
   align-self: flex-start;
   text-align: center;
   top: 0%;
-  width: 30vw;
+  width: 28vw;
   padding: 2vh;
   background-color: ${({ theme }) => theme.color.primary1};
   font-size: ${({ theme }) => theme.fontSize.title};
@@ -77,7 +77,7 @@ const TaskCardContainer: React.FC<IProps> = ({ taskList, status }) => {
     const elemBelow = document.elementFromPoint(event.clientX, event.clientY)! as HTMLElement;
     const container = elemBelow.closest('.CardContainer')! as HTMLDivElement;
     const currentTask = mindNodes.get(nodeId)!;
-    if (currentTask.status !== container.dataset.status) {
+    if (container && currentTask.status !== container.dataset.status) {
       updateTaskInformation({
         nodeFrom: nodeId,
         nodeTo: nodeId,

--- a/client/src/hooks/useProject/index.ts
+++ b/client/src/hooks/useProject/index.ts
@@ -22,7 +22,7 @@ const useProject = () => {
     if (roomId === projectId) {
       return;
     }
-    const projectInfo = await project.getInfo(roomId);
+    const { projectInfo, projectNodeInfo } = await project.getInfo(roomId);
 
     setProjectId(roomId);
 
@@ -39,12 +39,12 @@ const useProject = () => {
     setLabelList(labelList);
 
     const initNodes = new Map(
-      projectInfo.mindmap.map((node) => {
+      projectNodeInfo.map((node) => {
         const { id: nodeId, ...props } = node;
         return [nodeId, { nodeId, ...props }];
       })
     );
-    const rootId = projectInfo.mindmap.filter((node) => node.level === 'ROOT')[0].id;
+    const rootId = projectNodeInfo.filter((node) => node.level === 'ROOT')[0].id;
     setMindmap({ rootId: rootId as number, mindNodes: initNodes as IMindNodes });
   };
 

--- a/client/src/types/event.ts
+++ b/client/src/types/event.ts
@@ -32,14 +32,14 @@ export type TUpdateNodeContent = {
   content: string;
 };
 export type TTask = {
-  assignee?: string;
+  assigneeId?: string;
   labels?: number[];
   priority?: string;
   dueDate?: string;
   estimatedTime?: string;
   status?: 'To Do' | 'In Progress' | 'Done';
   finishedTime?: string;
-  sprint?: number;
+  sprintId?: number;
 };
 export type TUpdateTaskInformation = {
   changed: TTask;

--- a/client/src/types/project.ts
+++ b/client/src/types/project.ts
@@ -13,7 +13,7 @@ export interface IProject {
   createdAt: Date;
 }
 
-interface IMindmapData extends Partial<IMindNode> {
+export interface IMindmapData extends Partial<IMindNode> {
   id?: number;
   createdAt: string;
 }

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { IProject } from 'types/project';
+import { IMindmapData, IProject } from 'types/project';
 
 const api = axios.create({
   baseURL: process.env.REACT_APP_SERVER + 'api',
@@ -40,7 +40,7 @@ export const project = {
     });
     return userList;
   },
-  getInfo: async (projectId: string): Promise<IProject> => {
+  getInfo: async (projectId: string): Promise<{ projectInfo: IProject; projectNodeInfo: IMindmapData[] }> => {
     const info = await api.get('/project/info', {
       params: { projectId },
     });

--- a/server/src/database/entities/Mindmap.ts
+++ b/server/src/database/entities/Mindmap.ts
@@ -32,6 +32,6 @@ export class Mindmap {
   @OneToMany(() => Comment, (comment) => comment.node, { cascade: true })
   comment: Comment[];
 
-  @OneToOne(() => Task, (task) => task.nodeId, { cascade: true, nullable: true })
+  @OneToOne(() => Task, (task) => task.taskId, { cascade: true, nullable: true })
   task: Task;
 }

--- a/server/src/database/entities/Task.ts
+++ b/server/src/database/entities/Task.ts
@@ -7,8 +7,8 @@ import { User } from './User';
 @Entity()
 export class Task {
   @OneToOne(() => Mindmap, (mindmap) => mindmap.task, { primary: true, onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'nodeId' })
-  nodeId: Mindmap;
+  @JoinColumn({ name: 'taskId' })
+  taskId: Mindmap;
 
   @Column({ nullable: true })
   priority: string;

--- a/server/src/routes/project.ts
+++ b/server/src/routes/project.ts
@@ -49,8 +49,10 @@ router.get('/info', async (req: Request, res: Response, next: Next) => {
   try {
     const { projectId } = req.query;
     const projectInfo = await projectService.getProjectInfo(projectId);
-    projectInfo.mindmap.forEach((node) => (node.children = JSON.parse(node.children)));
-    res.send(projectInfo);
+    const projectNodeInfo = await projectService.getProjectNodeInfo(projectId);
+
+    projectNodeInfo.forEach((node) => (node.children = JSON.parse(node.children)));
+    res.send({ projectInfo, projectNodeInfo });
   } catch (e) {
     next(e);
   }

--- a/server/src/services/project.ts
+++ b/server/src/services/project.ts
@@ -1,4 +1,4 @@
-import { getConnection, getRepository } from 'typeorm';
+import { getConnection, getManager, getRepository } from 'typeorm';
 import { Project } from '../database/entities/Project';
 import { createNode } from './mindmap';
 import { findOneUser } from './user';
@@ -64,8 +64,19 @@ export const getProjectInfo = async (projectId: string) => {
     .leftJoinAndSelect('project.users', 'users')
     .leftJoinAndSelect('project.sprints', 'sprints')
     .leftJoinAndSelect('project.labels', 'labels')
-    .leftJoinAndSelect('project.mindmap', 'mindmap')
-    .leftJoinAndSelect('mindmap.task', 'task')
+
     .where('project.id = :projectId', { projectId })
     .getOne();
+};
+
+export const getProjectNodeInfo = async (ProjectId: string) => {
+  return getManager().query(
+    `
+  SELECT *
+  FROM mindmap
+  LEFT JOIN task
+  ON mindmap.id = task.nodeId
+  WHERE mindmap.projectId = ? ;`,
+    [ProjectId]
+  );
 };

--- a/server/src/services/project.ts
+++ b/server/src/services/project.ts
@@ -75,7 +75,7 @@ export const getProjectNodeInfo = async (ProjectId: string) => {
   SELECT *
   FROM mindmap
   LEFT JOIN task
-  ON mindmap.id = task.nodeId
+  ON mindmap.id = task.taskId
   WHERE mindmap.projectId = ? ;`,
     [ProjectId]
   );

--- a/server/src/services/task.ts
+++ b/server/src/services/task.ts
@@ -6,17 +6,17 @@ import { findOneNode } from './mindmap';
 import { findOneSprint } from './sprint';
 import { findOneUser } from './user';
 
-export const findOneTask = async (nodeId: string) => {
-  return getRepository(Task).findOne({ relations: ['nodeId'], where: { nodeId } });
+export const findOneTask = async (taskId: string) => {
+  return getRepository(Task).findOne({ relations: ['taskId'], where: { taskId } });
 };
 
 export const createTask = async (taskId: number) => {
   const node = await findOneNode(taskId);
-  return getRepository(Task).save({ nodeId: node });
+  return getRepository(Task).save({ taskId: node });
 };
 
 export const deleteTask = async (taskId: number) => {
-  return getRepository(Task).createQueryBuilder('task').leftJoin('task.nodeId', 'nodeId').delete().where({ nodeId: taskId }).execute();
+  return getRepository(Task).createQueryBuilder('task').leftJoin('task.taskId', 'taskId').delete().where({ taskId: taskId }).execute();
 };
 
 const findOneOrCreate = async (taskId: number) => {
@@ -27,18 +27,18 @@ const findOneOrCreate = async (taskId: number) => {
 };
 
 export const updateTask = async (nodeFrom: number, { changed }: TUpdateTaskInformation) => {
-  const { assignee, labels, sprint, ...info } = changed;
+  const { assigneeId, labels, sprintId, ...info } = changed;
   const task = await findOneOrCreate(nodeFrom);
-  if (assignee) {
-    const newAssignee = await findOneUser(assignee.toString(10));
+  if (assigneeId) {
+    const newAssignee = await findOneUser(assigneeId.toString(10));
     task.assignee = newAssignee;
   }
   if (labels) {
     const newLabels = await getRepository(Label).findByIds(labels);
     task.labels = newLabels;
   }
-  if (sprint) {
-    const newSprint = await findOneSprint(sprint.toString(10));
+  if (sprintId) {
+    const newSprint = await findOneSprint(sprintId.toString(10));
     task.sprint = newSprint;
   }
   if (info) {

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -28,14 +28,14 @@ export type TUpdateNodeContent = {
   content: string;
 };
 export type TTask = {
-  assignee?: number;
+  assigneeId?: number;
   labels?: number[];
   priority?: string;
   dueDate?: string;
   estimatedTime?: string;
   status?: 'To Do' | 'In Progress' | 'Done';
   finishedTime?: string;
-  sprint?: number;
+  sprintId?: number;
 };
 export type TUpdateTaskInformation = {
   changed: TTask;


### PR DESCRIPTION
## 📑 제목
노드 정보 수정 반영

## 📎 관련 이슈
- #92 

## ✔️ 셀프 체크리스트
칸반 머지후 작동 확인

## 💬 작업 내용
태스크 정보 프론트엔드에서 정규화,
프로젝트 정보에서 태스크 상세정보 받아오는 로직 수정
상세정보창 선택 변경시 

## 🚧 PR 특이 사항
typeorm에서 leftjoin을 할 때, 외래키를 안들고 오는 이슈가 있었음.
재귀적인 left join을 하기보다, 쿼리를 두개로 나누는 것으로 해결함
typeorm문제로 외래키를 가져오기 위해 sql 사용
클라이언트에서 정규화되어 있는 데이터 사용으로 join 최소화

## 🕰 실제 소요 시간
6h 