### PR TITLE
FE에서 level 처리하도록 변경

### DIFF
--- a/client/src/components/organisms/Mindmap/index.tsx
+++ b/client/src/components/organisms/Mindmap/index.tsx
@@ -71,33 +71,24 @@ const changeNodeParent = ({ curNodes, nextNodes, nodeInfos, updateNodeParent, dr
     (nodenum) => nextNodes.get(nodenum!)!
   );
   const [draggedLevel, newParentLevel] = [draggedNode, newParentNode].map((node) => node!.level);
-  const [draggedLevelIdx, newParentLevelIdx] = [draggedLevel, newParentLevel].map((level) => levelToIdx(level));
+  const newParentLevelIdx = levelToIdx(newParentLevel);
   const draggedDepth = nodeInfos.get(draggedNodeNum!)!.depth;
   if (!checkMoveCondition({ draggedDepth, newParentLevelIdx })) return;
 
   oldParentNode.children = oldParentNode.children.filter((childNodeNum) => childNodeNum !== draggedNodeNum);
   if (!newParentNode.children.includes(draggedNodeNum!)) newParentNode.children.push(draggedNodeNum!);
-  const isLevelChanged = newParentLevelIdx + 1 !== draggedLevelIdx;
-  const changeNodeIds = [oldParentNodeNum, newParentNodeNum];
-  if (isLevelChanged) {
-    draggedNode.level = idxToLevel(newParentLevelIdx + 1);
-    draggedNode.children.forEach((childId) => {
-      const childLevel = idxToLevel(newParentLevelIdx + 2);
-      const childNode = nextNodes.get(childId)!;
-      childNode.level = childLevel;
-      changeNodeIds.push(childNode.nodeId);
-    });
-    changeNodeIds.push(draggedNode.nodeId);
-  }
 
   const payload = {
     nodeFrom: oldParentNodeNum!,
     nodeTo: newParentNodeNum!,
-    dataFrom: changeNodeIds.map((nodeId) => curNodes.get(nodeId!)),
-    dataTo: changeNodeIds.map((nodeId) => nextNodes.get(nodeId!)),
-  };
+    dataTo: {
+      nodeId: draggedNodeNum,
+      nodeType: draggedLevel,
+      nodeParentType: newParentLevel,
+    },
+  } as THistoryEventData;
 
-  updateNodeParent(payload as any);
+  updateNodeParent(payload);
 };
 
 const getNodeInfo = (nodeInfos: INodeInfos, nodeId: number, mindNodes: IMindNodes) => {

--- a/client/src/hooks/useProject/index.ts
+++ b/client/src/hooks/useProject/index.ts
@@ -8,6 +8,7 @@ import { IMindNodes } from 'types/mindmap';
 import { ISprint } from 'types/sprint';
 import { IUser } from 'types/user';
 import { project } from 'utils/api';
+import { setTreeLevel } from 'utils/helpers';
 
 const useProject = () => {
   const [projectId, setProjectId] = useRecoilState(projectIdState);
@@ -43,9 +44,10 @@ const useProject = () => {
         const { id: nodeId, ...props } = node;
         return [nodeId, { nodeId, ...props }];
       })
-    );
-    const rootId = projectNodeInfo.filter((node) => node.level === 'ROOT')[0].id;
-    setMindmap({ rootId: rootId as number, mindNodes: initNodes as IMindNodes });
+    ) as IMindNodes;
+    const rootId = projectInfo.rootId;
+    setTreeLevel(initNodes, rootId, 0);
+    setMindmap({ rootId: rootId, mindNodes: initNodes });
   };
 
   useEffect(() => {

--- a/client/src/types/event.ts
+++ b/client/src/types/event.ts
@@ -14,7 +14,6 @@ export type TDeleteNodeData = {
 };
 export type TAddNodeData = {
   content: string;
-  level: string;
 };
 export type TMoveNodeData = {
   posX?: string;
@@ -22,7 +21,8 @@ export type TMoveNodeData = {
 };
 export type TUpdateNodeParent = {
   nodeId: number;
-  nodeParentType: 'Project' | 'Epic' | 'Story';
+  nodeType: 'EPIC' | 'STORY' | 'TASK';
+  nodeParentType: 'ROOT' | 'EPIC' | 'STORY';
 };
 export type TUpdateNodeSibling = {
   parentId: number;

--- a/client/src/types/project.ts
+++ b/client/src/types/project.ts
@@ -10,6 +10,7 @@ export interface IProject {
   sprints: ISprint[];
   users: IUser[];
   mindmap: IMindmapData[];
+  rootId: number;
   createdAt: Date;
 }
 

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -1,4 +1,5 @@
 import { THistoryEventData } from 'types/event';
+import { IMindNodes } from 'types/mindmap';
 
 interface ICoord {
   x: number;
@@ -108,6 +109,12 @@ const fillPayload = (payload: THistoryEventData): THistoryEventData => ({
 
 const getChildLevel = (level: Levels): Levels => idxToLevel(levelToIdx(level) + 1);
 
+const setTreeLevel = (mindNodes: IMindNodes, nodeId: number, depth: number) => {
+  const node = mindNodes.get(nodeId)!;
+  node.level = idxToLevel(depth);
+  node.children.forEach((childId) => setTreeLevel(mindNodes, childId, depth + 1));
+};
+
 export {
   getChildLevel,
   fillPayload,
@@ -124,6 +131,7 @@ export {
   getRegexNumber,
   idxToLevel,
   levelToIdx,
+  setTreeLevel,
 };
 export type TRect = IRect;
 export type TCoord = ICoord;

--- a/server/src/database/entities/Mindmap.ts
+++ b/server/src/database/entities/Mindmap.ts
@@ -23,9 +23,6 @@ export class Mindmap {
   @Column({ default: null })
   posY: string;
 
-  @Column()
-  level: string;
-
   @CreateDateColumn()
   createdAt: Date;
 

--- a/server/src/database/entities/Project.ts
+++ b/server/src/database/entities/Project.ts
@@ -26,6 +26,12 @@ export class Project {
   @OneToMany(() => Mindmap, (mindmap) => mindmap.project, { cascade: true })
   mindmap: Mindmap[];
 
+  @Column({
+    name: 'rootId',
+    default: -1,
+  })
+  rootId: number;
+
   @OneToMany(() => Sprint, (sprint) => sprint.project, { cascade: true })
   sprints: Sprint[];
 

--- a/server/src/services/project.ts
+++ b/server/src/services/project.ts
@@ -71,7 +71,6 @@ export const getProjectInfo = async (projectId: string) => {
     .leftJoinAndSelect('project.users', 'users')
     .leftJoinAndSelect('project.sprints', 'sprints')
     .leftJoinAndSelect('project.labels', 'labels')
-
     .where('project.id = :projectId', { projectId })
     .getOne();
 };

--- a/server/src/services/project.ts
+++ b/server/src/services/project.ts
@@ -44,8 +44,15 @@ export const addUserToProject = async (userId: string, projectId: string) => {
 export const createProject = async (name: string, creator: string) => {
   const user = await findOneUser(creator);
   const newProject = await getRepository(Project).save({ name, creator: user, users: [user] });
-  createNode(newProject.id, null, { level: 'ROOT', content: name, posX: '0', posY: '0', children: JSON.stringify([]) });
-  return newProject;
+  const rootId = await createNode(newProject.id, null, {
+    level: 'ROOT',
+    content: name,
+    posX: '0',
+    posY: '0',
+    children: JSON.stringify([]),
+  });
+  newProject.rootId = rootId;
+  return getRepository(Project).save(newProject);
 };
 
 export const deleteProject = async (userId: string, projectId: string) => {

--- a/server/src/services/task.ts
+++ b/server/src/services/task.ts
@@ -19,6 +19,13 @@ export const deleteTask = async (taskId: number) => {
   return getRepository(Task).createQueryBuilder('task').leftJoin('task.taskId', 'taskId').delete().where({ taskId: taskId }).execute();
 };
 
+export const deleteChildTasks = async (storyId: number) => {
+  const storyNode = await findOneNode(storyId);
+  const taskNodes = JSON.parse(storyNode.children);
+  taskNodes.forEach((taskId) => deleteTask(taskId));
+  return taskNodes;
+};
+
 const findOneOrCreate = async (taskId: number) => {
   const task = await findOneTask(taskId.toString(10));
   if (task !== undefined) return task;

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -1,5 +1,5 @@
 import { createNode, updateNode, updateNodeParent, deleteNode } from '../services/mindmap';
-import { deleteTask, updateTask } from '../services/task';
+import { deleteChildTasks, deleteTask, updateTask } from '../services/task';
 import { createSprint, deleteSprint } from '../services/sprint';
 import { createLabel, deleteLabel } from '../services/label';
 import { createComment, deleteComment } from '../services/comment';
@@ -29,9 +29,10 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
       return;
     },
     UPDATE_NODE_PARENT: ({ nodeFrom, nodeTo, dataTo }) => {
-      const { nodeId, nodeParentType } = dataTo as eventType.TUpdateNodeParent;
+      const { nodeId, nodeType, nodeParentType } = dataTo as eventType.TUpdateNodeParent;
       updateNodeParent(nodeFrom, nodeTo, nodeId);
-      if (nodeParentType !== 'STORY') deleteTask(nodeId);
+      if (nodeType === 'TASK' && nodeParentType !== 'STORY') deleteTask(nodeId);
+      if (nodeType === 'STORY' && nodeParentType !== 'EPIC') deleteChildTasks(nodeId);
       return;
     },
     UPDATE_NODE_SIBLING: ({ dataTo }) => {

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -10,7 +10,6 @@ export type TDeleteNodeData = {
 };
 export type TAddNodeData = {
   content: string;
-  level: string;
 };
 export type TMoveNodeData = {
   posX?: string;
@@ -18,7 +17,8 @@ export type TMoveNodeData = {
 };
 export type TUpdateNodeParent = {
   nodeId: number;
-  nodeParentType: 'PROJECT' | 'EPIC' | 'STORY';
+  nodeType: 'EPIC' | 'STORY' | 'TASK';
+  nodeParentType: 'ROOT' | 'EPIC' | 'STORY';
 };
 export type TUpdateNodeSibling = {
   parentId: number;


### PR DESCRIPTION
## 📑 제목
FE에서 level 처리하도록 변경
## 📎 관련 이슈
- #51 

## ✔️ 셀프 체크리스트
- [X] UPDATE_NODE_PARENT 로직 개선

## 💬 작업 내용
- DB Project entity에 level 제거, rootId추가
- UPDATE_NODE_PARENT FE에서 level 계산하도록 로직 변경

## 🚧 PR 특이 사항
- DB스키마 변경 seed 반영 필요

## 🕰 실제 소요 시간
6hr