### PR TITLE
마인드맵 필터링, 스프린트,라벨 삭제

### DIFF
--- a/client/src/components/molecules/PopupLayout/style.ts
+++ b/client/src/components/molecules/PopupLayout/style.ts
@@ -67,6 +67,9 @@ export const PopupHeader = styled.div<IStyleProps>`
   p {
     font-weight: bold;
     z-index: 1;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
   }
   img {
     cursor: pointer;

--- a/client/src/components/organisms/ConfirmModal/index.tsx
+++ b/client/src/components/organisms/ConfirmModal/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ModalOverlay, SmallText } from 'components/atoms';
+import { PopupLayout, TextButton } from 'components/molecules';
+import useModal from 'hooks/useModal';
+import { BottomButtonWrapper } from './style';
+
+export interface IConfirmModalProps {
+  onClickSubmitButton?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onCancelButton?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  title?: string;
+  text?: string;
+}
+
+const ConfirmModal: React.FC<IConfirmModalProps> = ({ onClickSubmitButton = () => {}, onCancelButton = () => {}, title, text }) => {
+  const { hideModal } = useModal();
+  return (
+    <>
+      <ModalOverlay visible={true} onClick={hideModal} />
+      <PopupLayout title={title} popupStyle={'modal'} onClose={hideModal}>
+        <SmallText color={'black'} weight={'normal'} margin={'2rem 0 2rem 0'}>
+          {text}
+        </SmallText>
+        <BottomButtonWrapper>
+          <TextButton onClick={onCancelButton} text={'취소'} textColor={'red'} textWeight={'bold'} margin={'0 auto 0 0'} />
+          <TextButton onClick={onClickSubmitButton} text={'확인'} textColor={'black'} textWeight={'bold'} margin={'0 0 0 auto'} />
+        </BottomButtonWrapper>
+      </PopupLayout>
+    </>
+  );
+};
+
+export default ConfirmModal;

--- a/client/src/components/organisms/ConfirmModal/style.ts
+++ b/client/src/components/organisms/ConfirmModal/style.ts
@@ -1,0 +1,5 @@
+import styled from '@emotion/styled';
+
+export const BottomButtonWrapper = styled.div`
+  ${({ theme }) => theme.flex.row}
+`;

--- a/client/src/components/organisms/FilterPopup/index.tsx
+++ b/client/src/components/organisms/FilterPopup/index.tsx
@@ -5,7 +5,7 @@ import { PopupItemLayout, PopupLayout } from 'components/molecules';
 import { ColorIcon, UserIcon } from 'components/atoms';
 import { ISOtoYYMMDD } from 'utils/form';
 import { assigneeFilterState, labelFilterState, labelListState, sprintFilterState, sprintListState, userListState } from 'recoil/project';
-import { plus } from 'img';
+import { closeIcon, plus } from 'img';
 import useModal from 'hooks/useModal';
 import useHistoryEmitter from 'hooks/useHistoryEmitter';
 
@@ -24,7 +24,7 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
   const labelList = useRecoilValue(labelListState);
 
   const { showModal, hideModal } = useModal();
-  const { addLabel } = useHistoryEmitter();
+  const { addLabel, deleteSprint } = useHistoryEmitter();
 
   const newLabelName = useRef<string>('');
 
@@ -36,6 +36,23 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
   const handleSetLabelFilter = (label: number) => setLabelFilter(label === labelFilter ? null : label);
 
   const handleClickAddSprint = () => showModal({ modalType: 'newSprintModal', modalProps: {} });
+  const handleClickDeleteSprintConfirm = () => {
+    deleteSprint({ sprintId: sprintFilter! });
+    setSprintFilter(null);
+    hideModal();
+  };
+  const handleClickDeleteSprint = () => {
+    showModal({
+      modalType: 'confirmModal',
+      modalProps: {
+        title: '스프린트 삭제',
+        text: `'${sprintList[sprintFilter!].name}' 스프린트를 삭제합니다`,
+        onClickSubmitButton: handleClickDeleteSprintConfirm,
+        onCancelButton: () => hideModal(),
+      },
+    });
+  };
+
   const handleChangeLabelInput = (event: React.ChangeEvent<HTMLInputElement>, ref: React.MutableRefObject<string>) =>
     (ref.current = event.target.value);
   const handleClickLabelSubmitEvent = () => {
@@ -94,9 +111,15 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
               );
             })}
           </FilterItemContainer>
-          <FilterButton onClick={handleClickAddSprint}>
-            <img src={plus} width={'16px'} height={'16px'} alt='추가하기' />
-          </FilterButton>
+          {sprintFilter ? (
+            <FilterButton onClick={handleClickDeleteSprint}>
+              <img src={closeIcon} width={'16px'} height={'16px'} alt='삭제하기' />
+            </FilterButton>
+          ) : (
+            <FilterButton onClick={handleClickAddSprint}>
+              <img src={plus} width={'16px'} height={'16px'} alt='추가하기' />
+            </FilterButton>
+          )}
         </PopupItemLayout>
       ) : (
         ''

--- a/client/src/components/organisms/FilterPopup/index.tsx
+++ b/client/src/components/organisms/FilterPopup/index.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { FilterMenuHeader, FilterItem, SprintItem, FilterButton, FilterItemContainer } from './style';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { PopupItemLayout, PopupLayout } from 'components/molecules';
@@ -30,38 +30,38 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
 
   const isSelected = (target: number | string, selected: number | string | null) => (target === selected ? 'selected' : '');
 
-  const handleFilterSelect = (filter: string) => setDisplayedFilter(filter);
-  const handleSetSprintFilter = (sprint: number) => setSprintFilter(sprint === sprintFilter ? null : sprint);
-  const handleSetAssigneeFilter = (assignee: string) => setAssigneeFilter(assignee === assigneeFilter ? null : assignee);
-  const handleSetLabelFilter = (label: number) => setLabelFilter(label === labelFilter ? null : label);
-
-  const handleClickAddSprint = () => showModal({ modalType: 'newSprintModal', modalProps: {} });
-  const handleClickDeleteSprintConfirm = () => {
+  const requestDeleteSprint = () => {
     deleteSprint({ sprintId: sprintFilter! });
     setSprintFilter(null);
     hideModal();
   };
-  const handleClickDeleteSprint = () => {
-    showModal({
-      modalType: 'confirmModal',
-      modalProps: {
-        title: '스프린트 삭제',
-        text: `'${sprintList[sprintFilter!].name}' 스프린트를 삭제합니다`,
-        onClickSubmitButton: handleClickDeleteSprintConfirm,
-        onCancelButton: () => hideModal(),
-      },
-    });
-  };
 
-  const handleChangeLabelInput = (event: React.ChangeEvent<HTMLInputElement>, ref: React.MutableRefObject<string>) =>
-    (ref.current = event.target.value);
-  const handleClickLabelSubmitEvent = () => {
+  const requestAddLabel = () => {
     if (!newLabelName.current) return;
     addLabel({ name: newLabelName.current });
     newLabelName.current = '';
     hideModal();
   };
-  const handleClickAddLabel = () => {
+
+  const requestDeleteLabel = () => {
+    deleteLabel({ labelId: labelFilter! });
+    setLabelFilter(null);
+    hideModal();
+  };
+
+  const showDeleteSprintModal = () => {
+    showModal({
+      modalType: 'confirmModal',
+      modalProps: {
+        title: '스프린트 삭제',
+        text: `'${sprintList[sprintFilter!].name}' 스프린트를 삭제합니다`,
+        onClickSubmitButton: () => requestDeleteSprint(),
+        onCancelButton: () => hideModal(),
+      },
+    });
+  };
+
+  const showAddLabelModal = () => {
     showModal({
       modalType: 'textInputModal',
       modalProps: {
@@ -69,28 +69,35 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
         text: '새로운 라벨 이름을 입력해주세요.',
         placeholder: '라벨 이름',
         onChangeInput: (e) => handleChangeLabelInput(e, newLabelName),
-        onClickSubmitButton: handleClickLabelSubmitEvent,
+        onClickSubmitButton: () => requestAddLabel(),
       },
     });
   };
 
-  const handleClickDeleteLabelConfirm = () => {
-    deleteLabel({ labelId: labelFilter! });
-    setLabelFilter(null);
-    hideModal();
-  };
-
-  const handleClickDeleteLabel = () => {
+  const showDeleteLabelModal = () => {
     showModal({
       modalType: 'confirmModal',
       modalProps: {
         title: '라벨 삭제',
         text: `'${labelList[labelFilter!].name}' 라벨을 삭제합니다.`,
-        onClickSubmitButton: handleClickDeleteLabelConfirm,
+        onClickSubmitButton: () => requestDeleteLabel(),
         onCancelButton: () => hideModal(),
       },
     });
   };
+
+  const handleFilterSelect = (filter: string) => setDisplayedFilter(filter);
+  const handleSetSprintFilter = (sprint: number) => setSprintFilter(sprint === sprintFilter ? null : sprint);
+  const handleSetAssigneeFilter = (assignee: string) => setAssigneeFilter(assignee === assigneeFilter ? null : assignee);
+  const handleSetLabelFilter = (label: number) => setLabelFilter(label === labelFilter ? null : label);
+
+  const handleClickAddSprint = () => showModal({ modalType: 'newSprintModal', modalProps: {} });
+  const handleClickDeleteSprint = () => showDeleteSprintModal();
+  const handleClickAddLabel = () => showAddLabelModal();
+  const handleClickDeleteLabel = () => showDeleteLabelModal();
+
+  const handleChangeLabelInput = (event: React.ChangeEvent<HTMLInputElement>, ref: React.MutableRefObject<string>) =>
+    (ref.current = event.target.value);
 
   const FilterMenu: React.FC<{ menu: string }> = ({ menu }) => (
     <span className={isSelected(menu, displayedFilter)} onClick={() => handleFilterSelect(menu)}>
@@ -98,13 +105,24 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
     </span>
   );
 
+  const DeleteButton: React.FC<{ onClick: React.MouseEventHandler }> = ({ onClick }) => (
+    <FilterButton onClick={onClick}>
+      <img src={closeIcon} width={'16px'} height={'16px'} alt='삭제하기' />
+    </FilterButton>
+  );
+
+  const AddButton: React.FC<{ onClick: React.MouseEventHandler }> = ({ onClick }) => (
+    <FilterButton onClick={onClick}>
+      <img src={plus} width={'16px'} height={'16px'} alt='추가하기' />
+    </FilterButton>
+  );
+
+  const popupTitle = `필터링: ${sprintFilter ? sprintList[sprintFilter].name : ''} ${assigneeFilter ? userList[assigneeFilter].name : ''} ${
+    labelFilter ? labelList[labelFilter].name : ''
+  }`;
+
   return (
-    <PopupLayout
-      title={`필터링: ${sprintFilter ? sprintList[sprintFilter].name : ''} ${assigneeFilter ? userList[assigneeFilter].name : ''} ${
-        labelFilter ? labelList[labelFilter].name : ''
-      }`}
-      onClose={onClose}
-    >
+    <PopupLayout title={popupTitle} onClose={onClose}>
       <FilterMenuHeader>
         <FilterMenu menu={'스프린트'} />
         <FilterMenu menu={'담당자'} />
@@ -129,15 +147,7 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
               );
             })}
           </FilterItemContainer>
-          {sprintFilter ? (
-            <FilterButton onClick={handleClickDeleteSprint}>
-              <img src={closeIcon} width={'16px'} height={'16px'} alt='삭제하기' />
-            </FilterButton>
-          ) : (
-            <FilterButton onClick={handleClickAddSprint}>
-              <img src={plus} width={'16px'} height={'16px'} alt='추가하기' />
-            </FilterButton>
-          )}
+          {sprintFilter ? <DeleteButton onClick={handleClickDeleteSprint} /> : <AddButton onClick={handleClickAddSprint} />}
         </PopupItemLayout>
       ) : (
         ''
@@ -170,15 +180,7 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
               );
             })}
           </FilterItemContainer>
-          {labelFilter ? (
-            <FilterButton onClick={handleClickDeleteLabel}>
-              <img src={closeIcon} width={'16px'} height={'16px'} alt='삭제하기' />
-            </FilterButton>
-          ) : (
-            <FilterButton onClick={handleClickAddLabel}>
-              <img src={plus} width={'16px'} height={'16px'} alt='추가하기' />
-            </FilterButton>
-          )}
+          {labelFilter ? <DeleteButton onClick={handleClickDeleteLabel} /> : <AddButton onClick={handleClickAddLabel} />}
         </PopupItemLayout>
       ) : (
         ''

--- a/client/src/components/organisms/FilterPopup/index.tsx
+++ b/client/src/components/organisms/FilterPopup/index.tsx
@@ -16,8 +16,8 @@ interface IProps {
 const FilterPopup: React.FC<IProps> = ({ onClose }) => {
   const [displayedFilter, setDisplayedFilter] = useState('스프린트');
   const [assigneeFilter, setAssigneeFilter] = useState<string | null>(null); // 추후에 recoil로
-  const [sprintFilter, setSprintFilter] = useState<string | null>(null); // 추후에 recoil로
-  const [labelFilter, setLabelFilter] = useState<string | null>(null); // 추후에 recoil로
+  const [sprintFilter, setSprintFilter] = useState<number | null>(null); // 추후에 recoil로
+  const [labelFilter, setLabelFilter] = useState<number | null>(null); // 추후에 recoil로
 
   const sprintList = useRecoilValue(sprintListState);
   const userList = useRecoilValue(userListState);
@@ -28,12 +28,12 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
 
   const newLabelName = useRef<string>('');
 
-  const isSelected = (target: string, selected: string | null) => (target === selected ? 'selected' : '');
+  const isSelected = (target: number | string, selected: number | string | null) => (target === selected ? 'selected' : '');
 
   const handleFilterSelect = (filter: string) => setDisplayedFilter(filter);
-  const handleSetSprintFilter = (sprint: string) => setSprintFilter(sprint === sprintFilter ? null : sprint);
+  const handleSetSprintFilter = (sprint: number) => setSprintFilter(sprint === sprintFilter ? null : sprint);
   const handleSetAssigneeFilter = (assignee: string) => setAssigneeFilter(assignee === assigneeFilter ? null : assignee);
-  const handleSetLabelFilter = (label: string) => setLabelFilter(label === labelFilter ? null : label);
+  const handleSetLabelFilter = (label: number) => setLabelFilter(label === labelFilter ? null : label);
 
   const handleClickAddSprint = () => showModal({ modalType: 'newSprintModal', modalProps: {} });
   const handleChangeLabelInput = (event: React.ChangeEvent<HTMLInputElement>, ref: React.MutableRefObject<string>) =>
@@ -64,7 +64,12 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
   );
 
   return (
-    <PopupLayout title={`필터링: ${sprintFilter ?? ''} ${assigneeFilter ?? ''} ${labelFilter ?? ''}`} onClose={onClose}>
+    <PopupLayout
+      title={`필터링: ${sprintFilter ? sprintList[sprintFilter].name : ''} ${assigneeFilter ? userList[assigneeFilter].name : ''} ${
+        labelFilter ? labelList[labelFilter].name : ''
+      }`}
+      onClose={onClose}
+    >
       <FilterMenuHeader>
         <FilterMenu menu={'스프린트'} />
         <FilterMenu menu={'담당자'} />
@@ -74,14 +79,10 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
         <PopupItemLayout>
           {Object.values(sprintList).map((sprint) => {
             return (
-              <FilterItem
-                key={sprint.id}
-                className={isSelected(sprint.name, sprintFilter)}
-                onClick={() => handleSetSprintFilter(sprint.name)}
-              >
+              <FilterItem key={sprint.id} className={isSelected(sprint.id, sprintFilter)} onClick={() => handleSetSprintFilter(sprint.id)}>
                 <SprintItem>
                   <ColorIcon color={sprint.color} />
-                  <span>{sprint.name}</span>
+                  <span>{sprintList[sprint.id].name}</span>
                   <span>{`${ISOtoYYMMDD(sprint.startDate)}~${ISOtoYYMMDD(sprint.endDate)}`}</span>
                 </SprintItem>
               </FilterItem>
@@ -98,13 +99,9 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
         <PopupItemLayout>
           {Object.values(userList).map((user) => {
             return (
-              <FilterItem
-                key={user.id}
-                className={isSelected(user.name, assigneeFilter)}
-                onClick={() => handleSetAssigneeFilter(user.name)}
-              >
+              <FilterItem key={user.id} className={isSelected(user.id, assigneeFilter)} onClick={() => handleSetAssigneeFilter(user.id)}>
                 <UserIcon user={user} />
-                {user.name}
+                {userList[user.id].name}
               </FilterItem>
             );
           })}
@@ -116,9 +113,9 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
         <PopupItemLayout>
           {Object.values(labelList).map((label) => {
             return (
-              <FilterItem key={label.id} className={isSelected(label.name, labelFilter)} onClick={() => handleSetLabelFilter(label.name)}>
+              <FilterItem key={label.id} className={isSelected(label.id, labelFilter)} onClick={() => handleSetLabelFilter(label.id)}>
                 <ColorIcon color={label.color} />
-                {label.name}
+                {labelList[label.id].name}
               </FilterItem>
             );
           })}

--- a/client/src/components/organisms/FilterPopup/index.tsx
+++ b/client/src/components/organisms/FilterPopup/index.tsx
@@ -1,10 +1,10 @@
 import { useRef, useState } from 'react';
 import { FilterMenuHeader, FilterItem, SprintItem, FilterButton } from './style';
-import { useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { PopupItemLayout, PopupLayout } from 'components/molecules';
 import { ColorIcon, UserIcon } from 'components/atoms';
 import { ISOtoYYMMDD } from 'utils/form';
-import { labelListState, sprintListState, userListState } from 'recoil/project';
+import { assigneeFilterState, labelFilterState, labelListState, sprintFilterState, sprintListState, userListState } from 'recoil/project';
 import { plus } from 'img';
 import useModal from 'hooks/useModal';
 import useHistoryEmitter from 'hooks/useHistoryEmitter';
@@ -15,10 +15,10 @@ interface IProps {
 
 const FilterPopup: React.FC<IProps> = ({ onClose }) => {
   const [displayedFilter, setDisplayedFilter] = useState('스프린트');
-  const [assigneeFilter, setAssigneeFilter] = useState<string | null>(null); // 추후에 recoil로
-  const [sprintFilter, setSprintFilter] = useState<number | null>(null); // 추후에 recoil로
-  const [labelFilter, setLabelFilter] = useState<number | null>(null); // 추후에 recoil로
 
+  const [assigneeFilter, setAssigneeFilter] = useRecoilState(assigneeFilterState);
+  const [sprintFilter, setSprintFilter] = useRecoilState(sprintFilterState);
+  const [labelFilter, setLabelFilter] = useRecoilState(labelFilterState);
   const sprintList = useRecoilValue(sprintListState);
   const userList = useRecoilValue(userListState);
   const labelList = useRecoilValue(labelListState);

--- a/client/src/components/organisms/FilterPopup/index.tsx
+++ b/client/src/components/organisms/FilterPopup/index.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from 'react';
-import { FilterMenuHeader, FilterItem, SprintItem, FilterButton } from './style';
+import { FilterMenuHeader, FilterItem, SprintItem, FilterButton, FilterItemContainer } from './style';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { PopupItemLayout, PopupLayout } from 'components/molecules';
 import { ColorIcon, UserIcon } from 'components/atoms';
@@ -77,17 +77,23 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
       </FilterMenuHeader>
       {displayedFilter === '스프린트' ? (
         <PopupItemLayout>
-          {Object.values(sprintList).map((sprint) => {
-            return (
-              <FilterItem key={sprint.id} className={isSelected(sprint.id, sprintFilter)} onClick={() => handleSetSprintFilter(sprint.id)}>
-                <SprintItem>
-                  <ColorIcon color={sprint.color} />
-                  <span>{sprintList[sprint.id].name}</span>
-                  <span>{`${ISOtoYYMMDD(sprint.startDate)}~${ISOtoYYMMDD(sprint.endDate)}`}</span>
-                </SprintItem>
-              </FilterItem>
-            );
-          })}
+          <FilterItemContainer>
+            {Object.values(sprintList).map((sprint) => {
+              return (
+                <FilterItem
+                  key={sprint.id}
+                  className={isSelected(sprint.id, sprintFilter)}
+                  onClick={() => handleSetSprintFilter(sprint.id)}
+                >
+                  <SprintItem>
+                    <ColorIcon color={sprint.color} />
+                    <span>{sprintList[sprint.id].name}</span>
+                    <span>{`${ISOtoYYMMDD(sprint.startDate)}~${ISOtoYYMMDD(sprint.endDate)}`}</span>
+                  </SprintItem>
+                </FilterItem>
+              );
+            })}
+          </FilterItemContainer>
           <FilterButton onClick={handleClickAddSprint}>
             <img src={plus} width={'16px'} height={'16px'} alt='추가하기' />
           </FilterButton>
@@ -97,28 +103,32 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
       )}
       {displayedFilter === '담당자' ? (
         <PopupItemLayout>
-          {Object.values(userList).map((user) => {
-            return (
-              <FilterItem key={user.id} className={isSelected(user.id, assigneeFilter)} onClick={() => handleSetAssigneeFilter(user.id)}>
-                <UserIcon user={user} />
-                {userList[user.id].name}
-              </FilterItem>
-            );
-          })}
+          <FilterItemContainer>
+            {Object.values(userList).map((user) => {
+              return (
+                <FilterItem key={user.id} className={isSelected(user.id, assigneeFilter)} onClick={() => handleSetAssigneeFilter(user.id)}>
+                  <UserIcon user={user} />
+                  {userList[user.id].name}
+                </FilterItem>
+              );
+            })}
+          </FilterItemContainer>
         </PopupItemLayout>
       ) : (
         ''
       )}
       {displayedFilter === '라벨' ? (
         <PopupItemLayout>
-          {Object.values(labelList).map((label) => {
-            return (
-              <FilterItem key={label.id} className={isSelected(label.id, labelFilter)} onClick={() => handleSetLabelFilter(label.id)}>
-                <ColorIcon color={label.color} />
-                {labelList[label.id].name}
-              </FilterItem>
-            );
-          })}
+          <FilterItemContainer>
+            {Object.values(labelList).map((label) => {
+              return (
+                <FilterItem key={label.id} className={isSelected(label.id, labelFilter)} onClick={() => handleSetLabelFilter(label.id)}>
+                  <ColorIcon color={label.color} />
+                  {labelList[label.id].name}
+                </FilterItem>
+              );
+            })}
+          </FilterItemContainer>
           <FilterButton onClick={handleClickAddLabel}>
             <img src={plus} width={'16px'} height={'16px'} alt='추가하기' />
           </FilterButton>

--- a/client/src/components/organisms/FilterPopup/index.tsx
+++ b/client/src/components/organisms/FilterPopup/index.tsx
@@ -24,7 +24,7 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
   const labelList = useRecoilValue(labelListState);
 
   const { showModal, hideModal } = useModal();
-  const { addLabel, deleteSprint } = useHistoryEmitter();
+  const { addLabel, deleteSprint, deleteLabel } = useHistoryEmitter();
 
   const newLabelName = useRef<string>('');
 
@@ -70,6 +70,24 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
         placeholder: '라벨 이름',
         onChangeInput: (e) => handleChangeLabelInput(e, newLabelName),
         onClickSubmitButton: handleClickLabelSubmitEvent,
+      },
+    });
+  };
+
+  const handleClickDeleteLabelConfirm = () => {
+    deleteLabel({ labelId: labelFilter! });
+    setLabelFilter(null);
+    hideModal();
+  };
+
+  const handleClickDeleteLabel = () => {
+    showModal({
+      modalType: 'confirmModal',
+      modalProps: {
+        title: '라벨 삭제',
+        text: `'${labelList[labelFilter!].name}' 라벨을 삭제합니다.`,
+        onClickSubmitButton: handleClickDeleteLabelConfirm,
+        onCancelButton: () => hideModal(),
       },
     });
   };
@@ -152,9 +170,15 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
               );
             })}
           </FilterItemContainer>
-          <FilterButton onClick={handleClickAddLabel}>
-            <img src={plus} width={'16px'} height={'16px'} alt='추가하기' />
-          </FilterButton>
+          {labelFilter ? (
+            <FilterButton onClick={handleClickDeleteLabel}>
+              <img src={closeIcon} width={'16px'} height={'16px'} alt='삭제하기' />
+            </FilterButton>
+          ) : (
+            <FilterButton onClick={handleClickAddLabel}>
+              <img src={plus} width={'16px'} height={'16px'} alt='추가하기' />
+            </FilterButton>
+          )}
         </PopupItemLayout>
       ) : (
         ''

--- a/client/src/components/organisms/FilterPopup/style.ts
+++ b/client/src/components/organisms/FilterPopup/style.ts
@@ -19,6 +19,13 @@ export const FilterMenuHeader = styled.div`
   }
 `;
 
+export const FilterItemContainer = styled.div`
+  position: relative;
+  display: block;
+  overflow-y: auto;
+  max-height: 4.5rem;
+`;
+
 export const FilterItem = styled.div`
   font-weight: bold;
   padding: 0.3rem 0.1rem;

--- a/client/src/components/organisms/FilterPopup/style.ts
+++ b/client/src/components/organisms/FilterPopup/style.ts
@@ -3,8 +3,9 @@ import styled from '@emotion/styled';
 export const FilterMenuHeader = styled.div`
   ${(props) => props.theme.flex.rowCenter};
   gap: 1rem;
-  margin: 0.3rem 0;
+  margin-top: 0.3rem;
   font-weight: bold;
+  line-height: 0.8;
   color: ${({ theme }) => theme.color.gray1};
 
   span {

--- a/client/src/components/organisms/index.tsx
+++ b/client/src/components/organisms/index.tsx
@@ -1,3 +1,4 @@
+export { default as ConfirmModal } from 'components/organisms/ConfirmModal';
 export { default as FilterPopup } from 'components/organisms/FilterPopup';
 export { default as ProjectCardContainer } from 'components/templates/ProjectCardContainer';
 export { default as NewProjectCard } from 'components/organisms/NewProjectCard';

--- a/client/src/components/templates/CommonLayout/style.ts
+++ b/client/src/components/templates/CommonLayout/style.ts
@@ -20,7 +20,7 @@ export const RightInfo = styled.div`
   position: fixed;
   top: 2.2rem;
   right: 0;
-  width: 270px;
+  width: 280px;
   padding: 1rem;
   z-index: 1;
 `;

--- a/client/src/components/templates/GlobalModal/index.tsx
+++ b/client/src/components/templates/GlobalModal/index.tsx
@@ -1,11 +1,12 @@
 import { useRecoilState } from 'recoil';
 import RegisterModal from 'components/organisms/RegisterModal';
-import { NewSprintModal, TextInputModal } from 'components/organisms';
+import { ConfirmModal, NewSprintModal, TextInputModal } from 'components/organisms';
 import { modalState } from 'recoil/modal';
 
-export type TModal = 'registerModal' | 'textInputModal';
+export type TModal = 'confirmModal' | 'registerModal' | 'textInputModal' | 'newSprintModal';
 
 const modalTypeToComponent = {
+  confirmModal: ConfirmModal,
   registerModal: RegisterModal,
   textInputModal: TextInputModal,
   newSprintModal: NewSprintModal,

--- a/client/src/hooks/useHistoryEmitter/index.ts
+++ b/client/src/hooks/useHistoryEmitter/index.ts
@@ -1,5 +1,5 @@
 import useToast from 'hooks/useToast';
-import { TAddLabel, TAddSprint, TEventData, TEventType, THistoryEventData, THistoryEventType } from 'types/event';
+import { TAddLabel, TAddSprint, TDeleteSprint, TEventData, TEventType, THistoryEventData, THistoryEventType } from 'types/event';
 import { fillPayload } from 'utils/helpers';
 
 export interface IHistoryEmitter {
@@ -34,6 +34,7 @@ const useHistoryEmitter = () => {
       showMessage('서버와의 연결이 불안정합니다');
       return;
     }
+    console.log(type, payload);
     window.socket.emit('non-history-event', type, JSON.stringify(payload));
   };
 
@@ -62,6 +63,7 @@ const useHistoryEmitter = () => {
   const addLabel = ({ name }: TAddLabel) => nonHistoryEmitter({ type: 'ADD_LABEL', payload: { name } });
   const addSprint = ({ name, startDate, endDate }: TAddSprint) =>
     nonHistoryEmitter({ type: 'ADD_SPRINT', payload: { name, startDate, endDate } });
+  const deleteSprint = ({ sprintId }: TDeleteSprint) => nonHistoryEmitter({ type: 'DELETE_SPRINT', payload: { sprintId } });
 
   return {
     addNode,
@@ -73,6 +75,7 @@ const useHistoryEmitter = () => {
     updateTaskInformation,
     addLabel,
     addSprint,
+    deleteSprint,
   };
 };
 

--- a/client/src/hooks/useHistoryEmitter/index.ts
+++ b/client/src/hooks/useHistoryEmitter/index.ts
@@ -1,5 +1,14 @@
 import useToast from 'hooks/useToast';
-import { TAddLabel, TAddSprint, TDeleteSprint, TEventData, TEventType, THistoryEventData, THistoryEventType } from 'types/event';
+import {
+  TAddLabel,
+  TAddSprint,
+  TDeleteLabel,
+  TDeleteSprint,
+  TEventData,
+  TEventType,
+  THistoryEventData,
+  THistoryEventType,
+} from 'types/event';
 import { fillPayload } from 'utils/helpers';
 
 export interface IHistoryEmitter {
@@ -61,6 +70,7 @@ const useHistoryEmitter = () => {
 
   //* non-history-event
   const addLabel = ({ name }: TAddLabel) => nonHistoryEmitter({ type: 'ADD_LABEL', payload: { name } });
+  const deleteLabel = ({ labelId }: TDeleteLabel) => nonHistoryEmitter({ type: 'DELETE_LABEL', payload: { labelId } });
   const addSprint = ({ name, startDate, endDate }: TAddSprint) =>
     nonHistoryEmitter({ type: 'ADD_SPRINT', payload: { name, startDate, endDate } });
   const deleteSprint = ({ sprintId }: TDeleteSprint) => nonHistoryEmitter({ type: 'DELETE_SPRINT', payload: { sprintId } });
@@ -74,6 +84,7 @@ const useHistoryEmitter = () => {
     updateNodeContent,
     updateTaskInformation,
     addLabel,
+    deleteLabel,
     addSprint,
     deleteSprint,
   };

--- a/client/src/hooks/useHistoryReceiver/index.ts
+++ b/client/src/hooks/useHistoryReceiver/index.ts
@@ -4,6 +4,7 @@ import { labelListState, sprintListState } from 'recoil/project';
 import {
   INonHistoryEventData,
   TAddNodeData,
+  TDeleteLabel,
   TDeleteSprint,
   THistoryEventData,
   TTask,
@@ -140,6 +141,14 @@ const nonHistoryEventHandler = ({ response, setLabelList, setSprintList }: INonH
     case 'ADD_LABEL':
       const newLabel = dbData as ILabel;
       setLabelList((prev) => ({ ...prev, [newLabel.id]: newLabel }));
+      break;
+    case 'DELETE_LABEL':
+      const { labelId } = data as TDeleteLabel;
+      setLabelList((prev) => {
+        const newLabelList = { ...prev };
+        delete newLabelList[labelId];
+        return newLabelList;
+      });
       break;
     case 'ADD_SPRINT':
       const newSprint = dbData as ISprint;

--- a/client/src/hooks/useHistoryReceiver/index.ts
+++ b/client/src/hooks/useHistoryReceiver/index.ts
@@ -4,6 +4,7 @@ import { labelListState, sprintListState } from 'recoil/project';
 import {
   INonHistoryEventData,
   TAddNodeData,
+  TDeleteSprint,
   THistoryEventData,
   TTask,
   TUpdateNodeContent,
@@ -133,7 +134,7 @@ interface INonHistoryEventHandlerProps {
 }
 
 const nonHistoryEventHandler = ({ response, setLabelList, setSprintList }: INonHistoryEventHandlerProps) => {
-  const { type, dbData } = response;
+  const { type, data, dbData } = response;
 
   switch (type) {
     case 'ADD_LABEL':
@@ -143,6 +144,14 @@ const nonHistoryEventHandler = ({ response, setLabelList, setSprintList }: INonH
     case 'ADD_SPRINT':
       const newSprint = dbData as ISprint;
       setSprintList((prev) => ({ ...prev, [newSprint.id]: newSprint }));
+      break;
+    case 'DELETE_SPRINT':
+      const { sprintId } = data as TDeleteSprint;
+      setSprintList((prev) => {
+        const newSprintList = { ...prev };
+        delete newSprintList[sprintId];
+        return newSprintList;
+      });
       break;
     default:
       break;

--- a/client/src/recoil/modal/index.ts
+++ b/client/src/recoil/modal/index.ts
@@ -2,6 +2,12 @@ import { atom } from 'recoil';
 import { IRegisterModalProps } from 'components/organisms/RegisterModal';
 import { ITextInputModalProps } from 'components/organisms/TextInputModal';
 import { INewSprintModalProps } from 'components/organisms/NewSprintModal';
+import { IConfirmModalProps } from 'components/organisms/ConfirmModal';
+
+export interface IConfirmModal {
+  modalType: 'confirmModal';
+  modalProps: IConfirmModalProps;
+}
 
 export interface IRegisterModal {
   modalType: 'registerModal';
@@ -18,6 +24,6 @@ export interface INewSprintModal {
   modalProps: INewSprintModalProps;
 }
 
-export type IModal = IRegisterModal | ITextInputModal | INewSprintModal;
+export type IModal = IConfirmModal | IRegisterModal | ITextInputModal | INewSprintModal;
 
 export const modalState = atom<IModal | null>({ key: 'modalState', default: null });

--- a/client/src/recoil/project/index.ts
+++ b/client/src/recoil/project/index.ts
@@ -1,29 +1,87 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
+import { mindmapNodesState } from 'recoil/mindmap';
 import { ILabel } from 'types/label';
+import { IMindNode } from 'types/mindmap';
 import { ISprint } from 'types/sprint';
 import { IUser } from 'types/user';
 
-export const projectIdState = atom<string | null>({
+const projectIdState = atom<string | null>({
   key: 'projectIdAtom',
   default: null,
 });
 
-export const sprintListState = atom<Record<number, ISprint>>({
+const sprintListState = atom<Record<number, ISprint>>({
   key: 'sprintList',
   default: {},
 });
 
-export const userListState = atom<Record<string, IUser>>({
+const userListState = atom<Record<string, IUser>>({
   key: 'userList',
   default: {},
 });
 
-export const connectedUserState = atom<Record<string, boolean>>({
+const connectedUserState = atom<Record<string, boolean>>({
   key: 'connectedUser',
   default: {},
 });
 
-export const labelListState = atom<Record<number, ILabel>>({
+const labelListState = atom<Record<number, ILabel>>({
   key: 'labelList',
   default: {},
 });
+
+const assigneeFilterState = atom<string | null>({
+  key: 'assigneeFilter',
+  default: null,
+});
+
+const sprintFilterState = atom<number | null>({
+  key: 'sprintFilter',
+  default: null,
+});
+
+const labelFilterState = atom<number | null>({
+  key: 'labelFilter',
+  default: null,
+});
+
+const filteredTaskState = selector<Record<number, IMindNode>>({
+  key: 'filteredTask',
+  get: ({ get }) => {
+    const nodes = get(mindmapNodesState);
+    const assigneeFilter = get(assigneeFilterState);
+    const sprintFilter = get(sprintFilterState);
+    const labelFilter = get(labelFilterState);
+    const filteredTask: Record<number, IMindNode> = {};
+
+    nodes.forEach((node) => {
+      if (node.level !== 'TASK') {
+        return;
+      }
+      if (assigneeFilter && node.assigneeId !== assigneeFilter) {
+        return;
+      }
+      if (sprintFilter && node.sprintId !== sprintFilter) {
+        return;
+      }
+      if (labelFilter && !node.labels?.includes(labelFilter)) {
+        return;
+      }
+      filteredTask[node.nodeId] = node;
+    });
+
+    return filteredTask;
+  },
+});
+
+export {
+  projectIdState,
+  sprintListState,
+  userListState,
+  connectedUserState,
+  labelListState,
+  assigneeFilterState,
+  sprintFilterState,
+  labelFilterState,
+  filteredTaskState,
+};

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -66,6 +66,7 @@ const eventFunction = (): Record<eventType.TEventType, TEventFunction> => {
     },
     DELETE_SPRINT: (data) => {
       const { sprintId } = data as eventType.TDeleteSprint;
+      console.log(sprintId);
       deleteSprint(sprintId);
       return;
     },


### PR DESCRIPTION
## 📑 제목
마인드맵 필터링, 스프린트,라벨 삭제

## 📎 관련 이슈
- #91
- #92 

## ✔️ 셀프 체크리스트
- [x] 라벨을 삭제할 수 있다.
- [x] 스프린트를 삭제할 수 있다.
- [x] 필터 선택을 통해 노드를 필터링 할 수 있다.
- [x] 소켓 반영 확인 

## 💬 작업 내용
필터 선택을 통한 필터링 노드(리코일)
확인 모달창
스프린트, 라벨 삭제
![녹화_2021_11_19_22_23_37_855](https://user-images.githubusercontent.com/73219421/142630575-e9a0b6cd-ec6d-41f8-a322-920761c43f06.gif)


## 🚧 PR 특이 사항
recoil/project에 filteredTask selector 만들었습니다.
스프린트는 모든 기능 완료
필터 팝업 컴포넌트 완성

## 🕰 실제 소요 시간
5h