### PR TITLE
마인드 맵 히스토리 반영 기능 #56

### DIFF
--- a/client/src/components/molecules/HistoryLog/index.tsx
+++ b/client/src/components/molecules/HistoryLog/index.tsx
@@ -6,19 +6,19 @@ import { Profile } from '..';
 import { Wrapper } from './style';
 
 interface IProps {
-  history: IHistoryData | null;
+  historyData: IHistoryData | null;
 }
 
-const HistoryLog: React.FC<IProps> = ({ history }) => {
+const HistoryLog: React.FC<IProps> = ({ historyData }) => {
   const userList = useRecoilValue(userListState);
 
   return (
     <Wrapper>
-      {history && userList ? (
+      {historyData && userList ? (
         <>
-          <Profile user={userList[history.user]} />
+          <Profile user={userList[historyData.user]} />
           <Title titleStyle='large' color='white' margin='0 0 0 1rem' lineHeight={2.5}>
-            {history.type}
+            {historyData.type}
           </Title>
         </>
       ) : null}

--- a/client/src/components/molecules/HistoryWindow/index.tsx
+++ b/client/src/components/molecules/HistoryWindow/index.tsx
@@ -4,30 +4,31 @@ import { MouseEvent } from 'react';
 import useDragBackground from 'hooks/useDragBackground';
 import { IHistoryData } from 'types/history';
 import { useRecoilValue } from 'recoil';
-import { historyDataState } from 'recoil/history';
+import { historyDataListState } from 'recoil/history';
 import { userListState } from 'recoil/project';
 
 interface IProps {
   onClick: (historyData: IHistoryData, idx: number) => (event: MouseEvent) => void;
-  currentHistory: IHistoryData;
+  currentHistoryData: IHistoryData | null;
 }
 
-const HistoryWindow: React.FC<IProps> = ({ onClick, currentHistory }) => {
+const HistoryWindow: React.FC<IProps> = ({ onClick, currentHistoryData }) => {
   const { containerRef, dragRef } = useDragBackground();
-  const historyData = useRecoilValue(historyDataState);
+  const historyDataList = useRecoilValue(historyDataListState);
   const userList = useRecoilValue(userListState);
+  const isSelected = (data: IHistoryData) => data.historyId === currentHistoryData?.historyId;
 
   return (
     <Wrapper ref={containerRef} className='background'>
-      {historyData && userList && currentHistory
-        ? historyData.map((historyDataPiece, idx) => (
+      {historyDataList.length && userList && currentHistoryData
+        ? historyDataList.map((historyData, idx) => (
             <IconWrapper
-              key={idx}
-              onClick={onClick(historyDataPiece, idx)}
-              isSelected={historyDataPiece.historyId === currentHistory.historyId}
-              color={userList[historyDataPiece.user].color}
+              key={historyData.historyId}
+              onClick={onClick(historyData, idx)}
+              isSelected={isSelected(historyData)}
+              color={userList[historyData.user].color}
             >
-              <UserIcon user={userList[historyDataPiece.user]} cursor='pointer' />
+              <UserIcon user={userList[historyData.user]} cursor='pointer' />
             </IconWrapper>
           ))
         : null}

--- a/client/src/components/molecules/HistoryWindow/index.tsx
+++ b/client/src/components/molecules/HistoryWindow/index.tsx
@@ -16,7 +16,7 @@ const HistoryWindow: React.FC<IProps> = ({ onClick, currentHistoryData }) => {
   const { containerRef, dragRef } = useDragBackground();
   const historyDataList = useRecoilValue(historyDataListState);
   const userList = useRecoilValue(userListState);
-  const isSelected = (data: IHistoryData) => data.historyId === currentHistoryData?.historyId;
+  const isSelected = (data: IHistoryData): boolean => currentHistoryData !== null && data.historyId === currentHistoryData.historyId;
 
   return (
     <Wrapper ref={containerRef} className='background'>

--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -1,5 +1,5 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { Node } from 'components/atoms';
 import { Path, TempNode } from 'components/molecules';
 import { TCoord, TRect, getCurrentCoord, getGap, getType, calcRect } from 'utils/helpers';
@@ -27,7 +27,7 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId
   const { addNode } = useHistoryEmitter();
   const setMindmapData = useSetRecoilState(mindmapState);
 
-  const selectedNodeId = useRecoilValue(selectedNodeIdState);
+  const [selectedNodeId, setSelectedNodeId] = useRecoilState(selectedNodeIdState);
   const isSelected = selectedNodeId === nodeId;
 
   const [coord, setCoord] = useState<TCoord | null>(null);
@@ -68,6 +68,7 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId
     };
 
     addNode(payload);
+    setSelectedNodeId(null);
   };
 
   const handleNodeContentFocusout = ({ currentTarget }: FormEvent<HTMLInputElement>) => {

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -25,16 +25,16 @@ const HistoryBar: React.FC = () => {
   };
 
   const handleHistoryClick = useCallback(
-    (historyDataPiece: IHistoryData) => () => {
+    (historyData: IHistoryData) => () => {
       if (!currentHistoryData) return handleCloseHistoryBtnClick();
-      if (currentHistoryData.historyId === historyDataPiece.historyId) return;
+      if (currentHistoryData.historyId === historyData.historyId) return;
 
-      const isForward = currentHistoryData.historyId < historyDataPiece.historyId;
-      const targetData = isForward ? historyDataPiece : currentHistoryData;
+      const isForward = currentHistoryData.historyId < historyData.historyId;
+      const targetData = isForward ? historyData : currentHistoryData;
       const params = { historyData: targetData, isForward, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
-      console.log(isForward, targetData, currentHistoryData);
+
       restoreHistory(params);
-      setCurrentHistoryData(historyDataPiece);
+      setCurrentHistoryData(historyData);
     },
     [currentHistoryData, historyDataList, historyMapData]
   );

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -23,24 +23,27 @@ const HistoryBar: React.FC = () => {
     resetHistoryMapData();
     linkToMindmap();
   };
+
   const handleHistoryClick = useCallback(
     (historyDataPiece: IHistoryData) => () => {
       if (!currentHistoryData) return handleCloseHistoryBtnClick();
       if (currentHistoryData.historyId === historyDataPiece.historyId) return;
+
       const isForward = currentHistoryData.historyId < historyDataPiece.historyId;
       const targetData = isForward ? historyDataPiece : currentHistoryData;
-      const params = { history: targetData, isForward, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
-      setCurrentHistoryData(() => historyDataPiece);
-      // restoreHistory(params);
+      const params = { historyData: targetData, isForward, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
+      console.log(isForward, targetData, currentHistoryData);
+      restoreHistory(params);
+      setCurrentHistoryData(historyDataPiece);
     },
-    [currentHistoryData]
+    [currentHistoryData, historyDataList, historyMapData]
   );
 
   useEffect(() => {
-    if (!historyDataList.length) return;
+    if (!historyDataList.length || currentHistoryData) return;
     const lastData = historyDataList.at(-1);
     setCurrentHistoryData(lastData!);
-  }, []);
+  }, [historyDataList]);
 
   return (
     <Wrapper>

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -3,41 +3,44 @@ import useLinkClick from 'hooks/useLinkClick';
 import { Wrapper, UpperDiv } from './style';
 import { Title } from 'components/atoms';
 import { HistoryLog, IconButton, PlayController, HistoryWindow } from 'components/molecules';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { IHistoryData } from 'types/history';
 import { useResetRecoilState, useRecoilState } from 'recoil';
-import { historyDataState } from 'recoil/history';
+import { historyDataListState } from 'recoil/history';
 import { historyMapDataState } from 'recoil/mindmap';
 import { restoreHistory } from 'utils/historyHandler';
 
 const HistoryBar: React.FC = () => {
-  const [historyData, setHistoryData] = useRecoilState(historyDataState);
-  const resetHistoryData = useResetRecoilState(historyDataState);
+  const [historyDataList, setHistoryDataList] = useRecoilState(historyDataListState);
+  const resetHistoryDataList = useResetRecoilState(historyDataListState);
   const resetHistoryMapData = useResetRecoilState(historyMapDataState);
   const [historyMapData, setHistoryMapData] = useRecoilState(historyMapDataState);
   const linkToMindmap = useLinkClick('mindmap');
-  const lastData = historyData[historyData.length - 1];
-  const [currentHistory, setCurrentHistory] = useState<IHistoryData>(lastData);
+  const [currentHistoryData, setCurrentHistoryData] = useState<IHistoryData | null>(null);
 
   const handleCloseHistoryBtnClick = () => {
-    resetHistoryData();
+    resetHistoryDataList();
     resetHistoryMapData();
     linkToMindmap();
   };
-  const handleHistoryClick = (historyDataPiece: IHistoryData) => () => {
-    if (currentHistory.historyId === historyDataPiece.historyId) return;
-
-    const isForward = currentHistory ? currentHistory.historyId < historyDataPiece.historyId : false;
-    const targetData = isForward ? historyDataPiece : currentHistory ?? lastData;
-    const params = { history: targetData, isForward, setHistoryMapData, setHistoryData, historyData, historyMapData };
-    restoreHistory(params);
-
-    setCurrentHistory(historyDataPiece);
-  };
+  const handleHistoryClick = useCallback(
+    (historyDataPiece: IHistoryData) => () => {
+      if (!currentHistoryData) return handleCloseHistoryBtnClick();
+      if (currentHistoryData.historyId === historyDataPiece.historyId) return;
+      const isForward = currentHistoryData.historyId < historyDataPiece.historyId;
+      const targetData = isForward ? historyDataPiece : currentHistoryData;
+      const params = { history: targetData, isForward, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
+      setCurrentHistoryData(() => historyDataPiece);
+      // restoreHistory(params);
+    },
+    [currentHistoryData]
+  );
 
   useEffect(() => {
-    setCurrentHistory(lastData);
-  }, [lastData]);
+    if (!historyDataList.length) return;
+    const lastData = historyDataList.at(-1);
+    setCurrentHistoryData(lastData!);
+  }, []);
 
   return (
     <Wrapper>
@@ -48,8 +51,8 @@ const HistoryBar: React.FC = () => {
         <PlayController />
         <IconButton imgSrc={whiteCloseBtn} onClick={handleCloseHistoryBtnClick} altText='히스토리 닫기 버튼'></IconButton>
       </UpperDiv>
-      <HistoryWindow onClick={handleHistoryClick} currentHistory={currentHistory} />
-      <HistoryLog history={currentHistory} />
+      <HistoryWindow onClick={handleHistoryClick} currentHistoryData={currentHistoryData} />
+      <HistoryLog historyData={currentHistoryData} />
     </Wrapper>
   );
 };

--- a/client/src/components/organisms/Mindmap/index.tsx
+++ b/client/src/components/organisms/Mindmap/index.tsx
@@ -86,6 +86,11 @@ const changeNodeParent = ({ nextNodes, nodeInfos, updateNodeParent, draggedElem,
       nodeType: draggedLevel,
       nodeParentType: newParentLevel,
     },
+    dataFrom: {
+      nodeId: draggedNodeNum,
+      nodeType: draggedLevel,
+      nodeParentType: oldParentNode.level,
+    },
   } as THistoryEventData;
 
   updateNodeParent(payload);

--- a/client/src/hooks/useHistoryController/index.ts
+++ b/client/src/hooks/useHistoryController/index.ts
@@ -1,7 +1,7 @@
 import { historyHandler } from 'hooks/useHistoryReceiver';
 import { useRef } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { historyDataState } from 'recoil/history';
+import { historyDataListState } from 'recoil/history';
 import { mindmapState } from 'recoil/mindmap';
 
 const useHistoryController = () => {

--- a/client/src/pages/History/index.tsx
+++ b/client/src/pages/History/index.tsx
@@ -32,6 +32,7 @@ const HistoryPage = () => {
 
   useEffect(() => {
     getNewHistoryData({ projectId, showMessage, setHistoryDataList });
+    return setHistoryDataList([]);
   }, []);
 
   return (

--- a/client/src/pages/History/index.tsx
+++ b/client/src/pages/History/index.tsx
@@ -3,7 +3,7 @@ import useProjectId from 'hooks/useRoomId';
 import useToast from 'hooks/useToast';
 import { useEffect } from 'react';
 import { SetterOrUpdater, useSetRecoilState } from 'recoil';
-import { historyDataState } from 'recoil/history';
+import { historyDataListState } from 'recoil/history';
 import { IHistoryData, THistoryRowData } from 'types/history';
 import { API } from 'utils/api';
 import { parseHistory } from 'utils/parser';
@@ -11,14 +11,14 @@ import { parseHistory } from 'utils/parser';
 interface IParams {
   projectId: string;
   showMessage: (message: string) => void;
-  setHistoryData: SetterOrUpdater<IHistoryData[]>;
+  setHistoryDataList: SetterOrUpdater<IHistoryData[]>;
 }
 
-const getNewHistoryData = async ({ projectId, showMessage, setHistoryData }: IParams) => {
+const getNewHistoryData = async ({ projectId, showMessage, setHistoryDataList }: IParams) => {
   try {
     const historyRowData = await API.history.get(projectId);
     const historyData: IHistoryData[] = historyRowData.map((data: THistoryRowData) => parseHistory(data)).reverse();
-    setHistoryData((prev: IHistoryData[]) => [...historyData, ...prev]);
+    setHistoryDataList((prev: IHistoryData[]) => [...historyData, ...prev]);
   } catch (err) {
     console.log(err);
     showMessage('히스토리를 가져오지 못했습니다.');
@@ -26,12 +26,12 @@ const getNewHistoryData = async ({ projectId, showMessage, setHistoryData }: IPa
 };
 
 const HistoryPage = () => {
-  const setHistoryData = useSetRecoilState(historyDataState);
+  const setHistoryDataList = useSetRecoilState(historyDataListState);
   const projectId = useProjectId();
   const { showMessage } = useToast();
 
   useEffect(() => {
-    getNewHistoryData({ projectId, showMessage, setHistoryData });
+    getNewHistoryData({ projectId, showMessage, setHistoryDataList });
   }, []);
 
   return (

--- a/client/src/recoil/history/index.ts
+++ b/client/src/recoil/history/index.ts
@@ -1,8 +1,8 @@
 import { atom } from 'recoil';
 import { IHistoryData } from 'types/history';
 
-export const historyDataState = atom<IHistoryData[]>({
-  key: 'historyDataAtom',
+export const historyDataListState = atom<IHistoryData[]>({
+  key: 'historyDataListAtom',
   default: [],
 });
 

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -1,6 +1,5 @@
 import { THistoryEventData } from 'types/event';
 import { IMindNodes } from 'types/mindmap';
-import { IUser } from 'types/user';
 
 interface ICoord {
   x: number;

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -110,7 +110,7 @@ const addNode = ({ history, historyMap }: IAddNodeParams) => {
   const newNode = history.data.dataTo
     ? { content, children: [], nodeId, level: getChildLevel(parent.level) }
     : { ...(history.data.dataFrom as TDeleteNodeData) };
-  console.log([...parent!.children, nodeId]);
+
   historyMap.set(parentId, { ...parent!, children: [...parent!.children, nodeId] });
   historyMap.set(nodeId, newNode as IMindNode);
 };
@@ -157,15 +157,15 @@ const deleteNode = ({ history, historyMap, historyData, setHistoryData }: IDelet
   const newChildren = history.data.dataFrom ? parent.children.filter((cid) => cid !== childId) : parent.children.slice(0, -1);
 
   historyMap.set(parentId, { ...parent, children: newChildren });
-  console.log(history.data);
   if (history.data.dataTo && !(history.data.dataTo! as TAddNodeData).nodeId) {
     const newDataTo = { ...history.data.dataTo, nodeId: childId };
     const newHistory = { ...history!, data: { ...history.data, dataTo: newDataTo } };
     const newList = [...historyData!];
     const index = newList.findIndex((d) => d.historyId === newHistory.historyId);
-    console.log('-----', newDataTo);
-    newList.splice(index - 1, 1, newHistory as IHistoryData);
-
+    console.log('-----', 'index : ', index, ' historyId : ', newHistory.historyId);
+    console.log('list1', newList);
+    newList.splice(index, 1, newHistory as IHistoryData);
+    console.log('list2', newList);
     setHistoryData!(newList);
   }
 };

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -3,15 +3,7 @@ import { getNextMapState } from 'recoil/mindmap';
 import { IMindmapData, IMindNode, IMindNodes } from 'types/mindmap';
 import { IHistoryData } from 'types/history';
 import { getChildLevel } from 'utils/helpers';
-import {
-  TAddNodeData,
-  TDeleteNodeData,
-  TMoveNodeData,
-  TUpdateNodeContent,
-  TUpdateNodeParent,
-  TUpdateNodeSibling,
-  TUpdateTaskInformation,
-} from 'types/event';
+import { TAddNodeData, TDeleteNodeData, TMoveNodeData, TUpdateNodeParent, TUpdateNodeSibling, TUpdateTaskInformation } from 'types/event';
 
 interface IParams {
   historyData: IHistoryData;
@@ -52,18 +44,12 @@ export const restoreHistory = (params: IParams) => {
       else moveNode({ data: historyData.data.dataFrom as TMoveNodeData, id: historyData.data.nodeFrom!, historyMap });
       break;
     case 'UPDATE_NODE_CONTENT':
-      if (isForward)
-        updateNodeContent({
-          id: historyData.data.nodeFrom!,
-          content: (historyData.data.dataTo! as TUpdateNodeContent).content,
-          historyMap,
-        });
-      else
-        updateNodeContent({
-          id: historyData.data.nodeTo!,
-          content: (historyData.data.dataFrom! as TUpdateNodeContent).content,
-          historyMap,
-        });
+      updateNodeContent({
+        historyData,
+        historyMap,
+        isForward,
+      });
+
       break;
     case 'UPDATE_NODE_PARENT':
       if (isForward)
@@ -119,16 +105,16 @@ const addNode = ({ historyData, historyMap }: IAddNodeParams) => {
 };
 
 interface IUpdateNodeContentParams {
-  id: number;
-  content: string;
+  historyData: IHistoryData;
   historyMap: IMindNodes;
+  isForward: boolean;
 }
 
-const updateNodeContent = ({ id, content, historyMap }: IUpdateNodeContentParams) => {
-  const node = historyMap.get(id);
-  node!.content = content;
+const updateNodeContent = ({ historyData, historyMap, isForward }: IUpdateNodeContentParams) => {
+  const { nodeFrom: id, dataFrom, dataTo } = historyData.data;
+  const node = historyMap.get(id!)!;
 
-  historyMap.set(id, node!);
+  historyMap.set(id!, { ...node, ...(isForward ? dataTo : dataFrom) });
 };
 
 interface IMoveNodeParams {

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -14,80 +14,81 @@ import {
 } from 'types/event';
 
 interface IParams {
-  history: IHistoryData;
+  historyData: IHistoryData;
   isForward: boolean;
   setHistoryMapData: SetterOrUpdater<IMindmapData>;
-  setHistoryData: SetterOrUpdater<IHistoryData[]>;
-  historyData: IHistoryData[];
+  setHistoryDataList: SetterOrUpdater<IHistoryData[]>;
+  historyDataList: IHistoryData[];
   historyMapData: IMindmapData;
 }
 
 export const restoreHistory = (params: IParams) => {
-  const { history, isForward, setHistoryMapData, setHistoryData, historyData, historyMapData } = params;
+  const { historyData, isForward, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData } = params;
   const historyMap = historyMapData.mindNodes;
 
-  switch (history.type) {
+  switch (historyData.type) {
     case 'ADD_NODE':
       if (isForward)
         addNode({
-          history,
+          historyData,
           historyMap,
         });
       else
         deleteNode({
-          history,
-          historyMap,
-          setHistoryData,
           historyData,
+          historyMap,
+          setHistoryDataList,
+          historyDataList,
         });
 
       break;
     case 'DELETE_NODE':
-      if (isForward) deleteNode({ history, historyMap });
+      if (isForward) deleteNode({ historyData, historyMap });
       else {
       }
       break;
     case 'MOVE_NODE':
-      if (isForward) moveNode({ data: history.data.dataTo as TMoveNodeData, id: history.data.nodeFrom!, historyMap });
-      else moveNode({ data: history.data.dataFrom as TMoveNodeData, id: history.data.nodeFrom!, historyMap });
+      if (isForward) moveNode({ data: historyData.data.dataTo as TMoveNodeData, id: historyData.data.nodeFrom!, historyMap });
+      else moveNode({ data: historyData.data.dataFrom as TMoveNodeData, id: historyData.data.nodeFrom!, historyMap });
       break;
     case 'UPDATE_NODE_CONTENT':
       if (isForward)
         updateNodeContent({
-          id: history.data.nodeFrom!,
-          content: (history.data.dataTo! as TUpdateNodeContent).content,
+          id: historyData.data.nodeFrom!,
+          content: (historyData.data.dataTo! as TUpdateNodeContent).content,
           historyMap,
         });
       else
         updateNodeContent({
-          id: history.data.nodeTo!,
-          content: (history.data.dataFrom! as TUpdateNodeContent).content,
+          id: historyData.data.nodeTo!,
+          content: (historyData.data.dataFrom! as TUpdateNodeContent).content,
           historyMap,
         });
       break;
     case 'UPDATE_NODE_PARENT':
       if (isForward)
         updateNodeParent({
-          from: history.data.nodeFrom!,
-          to: history.data.nodeTo!,
-          data: history.data.dataTo as TUpdateNodeParent,
+          from: historyData.data.nodeFrom!,
+          to: historyData.data.nodeTo!,
+          data: historyData.data.dataTo as TUpdateNodeParent,
           historyMap,
         });
       else
         updateNodeParent({
-          from: history.data.nodeTo!,
-          to: history.data.nodeFrom!,
-          data: history.data.dataFrom as TUpdateNodeParent,
+          from: historyData.data.nodeTo!,
+          to: historyData.data.nodeFrom!,
+          data: historyData.data.dataFrom as TUpdateNodeParent,
           historyMap,
         });
       break;
     case 'UPDATE_NODE_SIBLING':
-      if (isForward) updateNodeSibling({ data: history.data.dataTo as TUpdateNodeSibling, historyMap });
-      else updateNodeSibling({ data: history.data.dataFrom as TUpdateNodeSibling, historyMap });
+      if (isForward) updateNodeSibling({ data: historyData.data.dataTo as TUpdateNodeSibling, historyMap });
+      else updateNodeSibling({ data: historyData.data.dataFrom as TUpdateNodeSibling, historyMap });
       break;
     case 'UPDATE_TASK_INFORMATION':
-      if (isForward) updateNodeInformation({ id: history.data.nodeFrom!, data: history.data.dataTo as TUpdateTaskInformation, historyMap });
-      else updateNodeInformation({ id: history.data.nodeFrom!, data: history.data.dataFrom as TUpdateTaskInformation, historyMap });
+      if (isForward)
+        updateNodeInformation({ id: historyData.data.nodeFrom!, data: historyData.data.dataTo as TUpdateTaskInformation, historyMap });
+      else updateNodeInformation({ id: historyData.data.nodeFrom!, data: historyData.data.dataFrom as TUpdateTaskInformation, historyMap });
       break;
   }
 
@@ -97,19 +98,21 @@ export const restoreHistory = (params: IParams) => {
 };
 
 interface IAddNodeParams {
-  history: IHistoryData;
+  historyData: IHistoryData;
   historyMap: IMindNodes;
 }
 
-const addNode = ({ history, historyMap }: IAddNodeParams) => {
-  const parentId = history.data.nodeFrom!;
+const addNode = ({ historyData, historyMap }: IAddNodeParams) => {
+  const parentId = historyData.data.nodeFrom!;
   const parent = historyMap.get(parentId)!;
-  const nodeId = history.data.dataTo ? (history.data.dataTo as TAddNodeData).nodeId! : (history.data.dataFrom as TDeleteNodeData).nodeId!;
+  const nodeId = historyData.data.dataTo
+    ? (historyData.data.dataTo as TAddNodeData).nodeId!
+    : (historyData.data.dataFrom as TDeleteNodeData).nodeId!;
 
-  const { content } = history.data.dataTo as TAddNodeData;
-  const newNode = history.data.dataTo
+  const { content } = historyData.data.dataTo as TAddNodeData;
+  const newNode = historyData.data.dataTo
     ? { content, children: [], nodeId, level: getChildLevel(parent.level) }
-    : { ...(history.data.dataFrom as TDeleteNodeData) };
+    : { ...(historyData.data.dataFrom as TDeleteNodeData) };
 
   historyMap.set(parentId, { ...parent!, children: [...parent!.children, nodeId] });
   historyMap.set(nodeId, newNode as IMindNode);
@@ -143,30 +146,29 @@ const moveNode = ({ data, id, historyMap }: IMoveNodeParams) => {
 };
 
 interface IDeleteNodeParams {
-  history: IHistoryData;
+  historyData: IHistoryData;
   historyMap: IMindNodes;
-  setHistoryData?: SetterOrUpdater<IHistoryData[]>;
-  historyData?: IHistoryData[];
+  setHistoryDataList?: SetterOrUpdater<IHistoryData[]>;
+  historyDataList?: IHistoryData[];
 }
 
-const deleteNode = ({ history, historyMap, historyData, setHistoryData }: IDeleteNodeParams) => {
-  const parentId = history.data.nodeFrom!;
+const deleteNode = ({ historyData, historyMap, historyDataList, setHistoryDataList }: IDeleteNodeParams) => {
+  const parentId = historyData.data.nodeFrom!;
   const parent = historyMap.get(parentId)!;
 
-  const childId = history.data.dataFrom ? (history.data.dataFrom as TDeleteNodeData).nodeId : parent.children[parent.children.length - 1];
-  const newChildren = history.data.dataFrom ? parent.children.filter((cid) => cid !== childId) : parent.children.slice(0, -1);
+  const childId = historyData.data.dataFrom
+    ? (historyData.data.dataFrom as TDeleteNodeData).nodeId
+    : parent.children[parent.children.length - 1];
+  const newChildren = historyData.data.dataFrom ? parent.children.filter((cid) => cid !== childId) : parent.children.slice(0, -1);
 
   historyMap.set(parentId, { ...parent, children: newChildren });
-  if (history.data.dataTo && !(history.data.dataTo! as TAddNodeData).nodeId) {
-    const newDataTo = { ...history.data.dataTo, nodeId: childId };
-    const newHistory = { ...history!, data: { ...history.data, dataTo: newDataTo } };
-    const newList = [...historyData!];
+  if (historyData.data.dataTo && !(historyData.data.dataTo! as TAddNodeData).nodeId) {
+    const newDataTo = { ...historyData.data.dataTo, nodeId: childId };
+    const newHistory = { ...historyData!, data: { ...historyData.data, dataTo: newDataTo } };
+    const newList = [...historyDataList!];
     const index = newList.findIndex((d) => d.historyId === newHistory.historyId);
-    console.log('-----', 'index : ', index, ' historyId : ', newHistory.historyId);
-    console.log('list1', newList);
     newList.splice(index, 1, newHistory as IHistoryData);
-    console.log('list2', newList);
-    setHistoryData!(newList);
+    setHistoryDataList!(newList);
   }
 };
 

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -196,6 +196,7 @@ interface IUpdateNodeInformationParams {
 }
 
 const updateNodeInformation = ({ id, data, historyMap }: IUpdateNodeInformationParams) => {
+  if (!data.changed.assigneeId) return;
   const node = historyMap.get(id)!;
 
   historyMap.set(id, { ...node, ...data.changed });

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -73,8 +73,8 @@ export const restoreHistory = (params: IParams) => {
       break;
     case 'UPDATE_TASK_INFORMATION':
       if (isForward)
-        updateNodeInformation({ id: historyData.data.nodeFrom!, data: historyData.data.dataTo as TUpdateTaskInformation, historyMap });
-      else updateNodeInformation({ id: historyData.data.nodeFrom!, data: historyData.data.dataFrom as TUpdateTaskInformation, historyMap });
+        updateTaskInformation({ id: historyData.data.nodeFrom!, data: historyData.data.dataTo as TUpdateTaskInformation, historyMap });
+      else updateTaskInformation({ id: historyData.data.nodeFrom!, data: historyData.data.dataFrom as TUpdateTaskInformation, historyMap });
       break;
   }
 
@@ -195,7 +195,7 @@ interface IUpdateNodeInformationParams {
   historyMap: IMindNodes;
 }
 
-const updateNodeInformation = ({ id, data, historyMap }: IUpdateNodeInformationParams) => {
+const updateTaskInformation = ({ id, data, historyMap }: IUpdateNodeInformationParams) => {
   if (!data.changed.assigneeId) return;
   const node = historyMap.get(id)!;
 


### PR DESCRIPTION
## 📑 제목
마인드 맵 히스토리 반영 기능 #56
## 📎 관련 이슈
- #56 
## ✔️ 셀프 체크리스트
- [x]  과거 히스토리로 돌아가면 해당 마인드맵을 그린다.
## 💬 작업 내용
- 히스토리 내역 클릭 시 에러나는 버그 수정
## 🚧 PR 특이 사항
- historyDataList, historyData 관련 변수명 통일
- historyDataList, currentHistoryData state 변경 로직 정리
- mindmap에서 updateParent 시 payload에 dataFrom 추가
- updateTaskInformation 응답 데이터에 맞게 수정 (이벤트 명세를 수정하기로 함)
## 🕰 실제 소요 시간
3h