### PR TITLE
인증 관리 커스텀훅

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["Mindmap", "typeorm", "xadd", "xread", "xrevrange"]
+  "cSpell.words": ["Mindmap", "typeorm", "xadd", "xread", "xrevrange", "middleware", "middlewares"]
 }

--- a/client/src/components/organisms/FilterPopup/index.tsx
+++ b/client/src/components/organisms/FilterPopup/index.tsx
@@ -131,21 +131,15 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
       {displayedFilter === '스프린트' ? (
         <PopupItemLayout>
           <FilterItemContainer>
-            {Object.values(sprintList).map((sprint) => {
-              return (
-                <FilterItem
-                  key={sprint.id}
-                  className={isSelected(sprint.id, sprintFilter)}
-                  onClick={() => handleSetSprintFilter(sprint.id)}
-                >
-                  <SprintItem>
-                    <ColorIcon color={sprint.color} />
-                    <span>{sprintList[sprint.id].name}</span>
-                    <span>{`${ISOtoYYMMDD(sprint.startDate)}~${ISOtoYYMMDD(sprint.endDate)}`}</span>
-                  </SprintItem>
-                </FilterItem>
-              );
-            })}
+            {Object.values(sprintList).map((sprint) => (
+              <FilterItem key={sprint.id} className={isSelected(sprint.id, sprintFilter)} onClick={() => handleSetSprintFilter(sprint.id)}>
+                <SprintItem>
+                  <ColorIcon color={sprint.color} />
+                  <span>{sprintList[sprint.id].name}</span>
+                  <span>{`${ISOtoYYMMDD(sprint.startDate)}~${ISOtoYYMMDD(sprint.endDate)}`}</span>
+                </SprintItem>
+              </FilterItem>
+            ))}
           </FilterItemContainer>
           {sprintFilter ? <DeleteButton onClick={handleClickDeleteSprint} /> : <AddButton onClick={handleClickAddSprint} />}
         </PopupItemLayout>
@@ -155,14 +149,12 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
       {displayedFilter === '담당자' ? (
         <PopupItemLayout>
           <FilterItemContainer>
-            {Object.values(userList).map((user) => {
-              return (
-                <FilterItem key={user.id} className={isSelected(user.id, assigneeFilter)} onClick={() => handleSetAssigneeFilter(user.id)}>
-                  <UserIcon user={user} />
-                  {userList[user.id].name}
-                </FilterItem>
-              );
-            })}
+            {Object.values(userList).map((user) => (
+              <FilterItem key={user.id} className={isSelected(user.id, assigneeFilter)} onClick={() => handleSetAssigneeFilter(user.id)}>
+                <UserIcon user={user} />
+                {userList[user.id].name}
+              </FilterItem>
+            ))}
           </FilterItemContainer>
         </PopupItemLayout>
       ) : (
@@ -171,14 +163,12 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
       {displayedFilter === '라벨' ? (
         <PopupItemLayout>
           <FilterItemContainer>
-            {Object.values(labelList).map((label) => {
-              return (
-                <FilterItem key={label.id} className={isSelected(label.id, labelFilter)} onClick={() => handleSetLabelFilter(label.id)}>
-                  <ColorIcon color={label.color} />
-                  {labelList[label.id].name}
-                </FilterItem>
-              );
-            })}
+            {Object.values(labelList).map((label) => (
+              <FilterItem key={label.id} className={isSelected(label.id, labelFilter)} onClick={() => handleSetLabelFilter(label.id)}>
+                <ColorIcon color={label.color} />
+                {labelList[label.id].name}
+              </FilterItem>
+            ))}
           </FilterItemContainer>
           {labelFilter ? <DeleteButton onClick={handleClickDeleteLabel} /> : <AddButton onClick={handleClickAddLabel} />}
         </PopupItemLayout>

--- a/client/src/components/organisms/FilterPopup/index.tsx
+++ b/client/src/components/organisms/FilterPopup/index.tsx
@@ -87,9 +87,9 @@ const FilterPopup: React.FC<IProps> = ({ onClose }) => {
   };
 
   const handleFilterSelect = (filter: string) => setDisplayedFilter(filter);
-  const handleSetSprintFilter = (sprint: number) => setSprintFilter(sprint === sprintFilter ? null : sprint);
-  const handleSetAssigneeFilter = (assignee: string) => setAssigneeFilter(assignee === assigneeFilter ? null : assignee);
-  const handleSetLabelFilter = (label: number) => setLabelFilter(label === labelFilter ? null : label);
+  const handleSetSprintFilter = (sprint: number) => setSprintFilter((prev) => (sprint === prev ? null : sprint));
+  const handleSetAssigneeFilter = (assignee: string) => setAssigneeFilter((prev) => (assignee === prev ? null : assignee));
+  const handleSetLabelFilter = (label: number) => setLabelFilter((prev) => (label === prev ? null : label));
 
   const handleClickAddSprint = () => showModal({ modalType: 'newSprintModal', modalProps: {} });
   const handleClickDeleteSprint = () => showDeleteSprintModal();

--- a/client/src/components/organisms/RegisterModal/index.tsx
+++ b/client/src/components/organisms/RegisterModal/index.tsx
@@ -3,7 +3,8 @@ import { ModalBox, ModalOverlay, Input, Title } from 'components/atoms';
 import { TextButton } from 'components/molecules';
 import useModal from 'hooks/useModal';
 import useToast from 'hooks/useToast';
-import { authApi } from 'utils/api';
+import { AxiosError } from 'axios';
+import { auth } from 'utils/api';
 
 export interface IRegisterModalProps {
   key?: string;
@@ -21,20 +22,20 @@ const RegisterModal: React.FC<IRegisterModalProps> = () => {
 
   const handleIdChange = (e: ChangeEvent<HTMLInputElement>) => (newUser.current.id = e.target.value);
   const handleNameChange = (e: ChangeEvent<HTMLInputElement>) => (newUser.current.name = e.target.value);
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (newUser.current.id === '' || newUser.current.name === '') {
       showMessage('아이디와 이름을 입력해주세요');
       return;
     }
-    authApi
-      .register(newUser.current.id, newUser.current.name)
-      .then((res) => {
-        if (res.status === 200) {
-          showMessage('가입되었습니다.');
-          hideModal();
-        }
-      })
-      .catch((err) => (err.response?.data.msg ? showMessage(err.response?.data.msg) : showError(err)));
+    try {
+      const res = await auth.register(newUser.current.id, newUser.current.name);
+      if (res.status === 200) {
+        showMessage('가입되었습니다.');
+        hideModal();
+      }
+    } catch (err) {
+      showError(err as Error | AxiosError);
+    }
   };
   return (
     <>

--- a/client/src/components/templates/CommonLayout/index.tsx
+++ b/client/src/components/templates/CommonLayout/index.tsx
@@ -1,17 +1,18 @@
 import { useState } from 'react';
-import { filterIcon } from 'img';
+import { LeftInfo, RightInfo, Template } from './style';
 import { BoxButton } from 'components/atoms';
 import { NodeDetailWrapper, UserList, Header, FilterPopup } from 'components/organisms';
 import useSocketSetup from 'hooks/useSocketSetup';
-
-import { LeftInfo, RightInfo, Template } from './style';
 import useProject from 'hooks/useProject';
+import useAuthentication from 'hooks/useAuthentication';
+import { filterIcon } from 'img';
 
 const CommonLayout: React.FC = ({ children }) => {
-  useSocketSetup();
   const [DisplayFilter, setDisplayFilter] = useState(false);
   const handleFilterButton = () => setDisplayFilter(true);
   const handleClickFilterPopupClose = () => setDisplayFilter(false);
+  useAuthentication();
+  useSocketSetup();
   useProject();
 
   return (

--- a/client/src/hooks/useAuthentication/index.ts
+++ b/client/src/hooks/useAuthentication/index.ts
@@ -1,0 +1,44 @@
+import useToast from 'hooks/useToast';
+import { useEffect } from 'react';
+import { useHistory } from 'react-router';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { isAuthenticatedState, userState } from 'recoil/user';
+import { auth } from 'utils/api';
+
+const useAuthentication = () => {
+  const [isAuth, setIsAuth] = useRecoilState(isAuthenticatedState);
+  const setUser = useSetRecoilState(userState);
+  const history = useHistory();
+  const { showMessage } = useToast();
+
+  const redirectToLoginPage = () => history.push({ pathname: '/', state: { link: history.location.pathname } });
+
+  const cleanAuthInfo = () => {
+    setIsAuth(false);
+    setUser(null);
+  };
+
+  const checkTokenStatus = async () => {
+    try {
+      const res = await auth.status();
+      if (res.status === 200) {
+        if (!isAuth) {
+          const cacheUser = JSON.parse(localStorage.getItem('user')!);
+          setIsAuth(true);
+          setUser(cacheUser);
+        }
+      }
+    } catch (err) {
+      showMessage('로그인이 필요합니다.');
+      cleanAuthInfo();
+      redirectToLoginPage();
+    }
+  };
+
+  useEffect(() => {
+    checkTokenStatus();
+    return () => cleanAuthInfo();
+  }, []);
+};
+
+export default useAuthentication;

--- a/client/src/hooks/useToast/index.ts
+++ b/client/src/hooks/useToast/index.ts
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { toastState } from 'recoil/toast';
+import axios, { AxiosError } from 'axios';
 
 const useToast = () => {
   const setToast = useSetRecoilState(toastState);
@@ -13,8 +14,14 @@ const useToast = () => {
     id.current = id.current + 1;
   };
 
-  const showError = (err: Error) => {
-    const message = err.message ?? '오류가 발생했습니다.';
+  const showError = (err: Error | AxiosError) => {
+    let message = '오류가 발생했습니다.';
+
+    if (axios.isAxiosError(err) && err.response?.data?.msg) {
+      message = err.response.data.msg;
+    } else if (err.message) {
+      message = err.message;
+    }
     setToast((toastList) => [...toastList, { id: id.current, show: true, message }]);
     const timerId = id.current;
     setTimeout(() => hideMessage(timerId), 2000);

--- a/client/src/pages/Project/index.tsx
+++ b/client/src/pages/Project/index.tsx
@@ -1,4 +1,5 @@
 import { ProjectCardContainer } from 'components/templates';
+import useAuthentication from 'hooks/useAuthentication';
 import useSocketDisconnect from 'hooks/useSocketDisconnect';
 import { useEffect, useState } from 'react';
 import { API } from 'utils/api';
@@ -17,6 +18,7 @@ export interface IProject {
 }
 
 const Project = () => {
+  useAuthentication();
   useSocketDisconnect();
   const [projectList, setProjectList] = useState([] as Array<IProject>);
   useEffect(() => {

--- a/client/src/recoil/user/index.ts
+++ b/client/src/recoil/user/index.ts
@@ -1,7 +1,12 @@
 import { atom } from 'recoil';
 import { IUser } from 'types/user';
 
-export const userState = atom<IUser>({
-  key: 'userAtom',
-  default: { id: 'chosh', name: '조성현', color: '000000', icon: 'frog' },
+export const isAuthenticatedState = atom({
+  key: 'isAuthenticated',
+  default: false,
+});
+
+export const userState = atom<IUser | null>({
+  key: 'user',
+  default: null,
 });

--- a/client/src/utils/api.ts
+++ b/client/src/utils/api.ts
@@ -8,7 +8,9 @@ const api = axios.create({
 
 const HISTORY_COUNT_TO_GET = 15;
 
-export const authApi = {
+export const auth = {
+  status: () => api.get('/auth/status'),
+
   login: (id: string) =>
     api.post('/auth/login', {
       id,
@@ -60,6 +62,7 @@ export const history = {
 };
 
 export const API = {
+  auth,
   project,
   history,
 };

--- a/server/src/routes/auth.ts
+++ b/server/src/routes/auth.ts
@@ -3,7 +3,10 @@ import { createCustomError } from '../utils';
 import * as userService from '../services/user';
 import * as authService from '../services/auth';
 import ErrorMessage from '../config/error-message';
+import { verifyToken } from '../middlewares/auth';
 const router = Router();
+
+router.get('/status', verifyToken, (req: Request, res: Response, next: Next) => res.sendStatus(200));
 
 router.post('/login', async (req: Request, res: Response, next: Next) => {
   try {
@@ -13,7 +16,7 @@ router.post('/login', async (req: Request, res: Response, next: Next) => {
       throw createCustomError(401, ErrorMessage.UNREGISTERED_USER);
     }
     const token = authService.createJWTToken(id);
-    res.cookie('token', token).sendStatus(200);
+    res.cookie('token', token).send(user);
   } catch (e) {
     next(e);
   }

--- a/server/src/services/auth.ts
+++ b/server/src/services/auth.ts
@@ -3,5 +3,5 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 
 export const createJWTToken = (id: string) => {
-  return jwt.sign({ id }, process.env.JWT_SECRET_KEY, { expiresIn: '1h' });
+  return jwt.sign({ id }, process.env.JWT_SECRET_KEY, { expiresIn: '6h' });
 };


### PR DESCRIPTION
## 📑 제목
클라이언트에서 인증 관리하는 커스텀훅 만들기

## 📎 관련 이슈
- #121

## ✔️ 셀프 체크리스트
 인증이 되어있다면, 유저정보를 업데이트한다.
 인증이 되어있다면, 현재 접속 링크를 저장하고, 로그인 페이지로 리다이렉트 시킨다.
 로그인 후, 기존 접속주소로 돌아오게 한다.
 새로고침후 유저정보가 유지되게한다.

## 💬 작업 내용
useAuthentication 커스텀 훅
auth api  관련 에러처리

## 🚧 PR 특이 사항
toast에 showError 에러 메시지 처리 용도로 많이 사용해주세요.

## 🕰 실제 소요 시간
2.5h