### PR TITLE
히스토리 리스트에서 특정 원을 클릭하면 현재 보고 있는 시점에서 클릭한 원까지의 변화 과정을 보여주며 이동한다. #66 / #124

### DIFF
--- a/client/src/components/molecules/HistoryLog/index.tsx
+++ b/client/src/components/molecules/HistoryLog/index.tsx
@@ -1,4 +1,5 @@
 import { Title } from 'components/atoms';
+import { useLog } from 'hooks/useLog';
 import { useRecoilValue } from 'recoil';
 import { userListState } from 'recoil/project';
 import { IHistoryData } from 'types/history';
@@ -11,6 +12,7 @@ interface IProps {
 
 const HistoryLog: React.FC<IProps> = ({ historyData }) => {
   const userList = useRecoilValue(userListState);
+  const getLog = useLog();
 
   return (
     <Wrapper>
@@ -18,7 +20,7 @@ const HistoryLog: React.FC<IProps> = ({ historyData }) => {
         <>
           <Profile user={userList[historyData.user]} />
           <Title titleStyle='large' color='white' margin='0 0 0 1rem' lineHeight={2.5}>
-            {historyData.type}
+            {getLog(historyData)}
           </Title>
         </>
       ) : null}

--- a/client/src/components/molecules/HistoryLog/index.tsx
+++ b/client/src/components/molecules/HistoryLog/index.tsx
@@ -19,7 +19,7 @@ const HistoryLog: React.FC<IProps> = ({ historyData }) => {
       {historyData && userList ? (
         <>
           <Profile user={userList[historyData.user]} />
-          <Title titleStyle='large' color='white' margin='0 0 0 1rem' lineHeight={2.5}>
+          <Title titleStyle='large' color='white' margin='0 0 0 1rem' lineHeight={2.3}>
             {getLog(historyData)}
           </Title>
         </>

--- a/client/src/components/molecules/HistoryWindow/index.tsx
+++ b/client/src/components/molecules/HistoryWindow/index.tsx
@@ -2,7 +2,6 @@ import { Wrapper, IconWrapper } from './style';
 import { DragTarget, UserIcon } from 'components/atoms';
 import { MouseEvent } from 'react';
 import useDragBackground from 'hooks/useDragBackground';
-import { IHistoryData } from 'types/history';
 import { useRecoilValue } from 'recoil';
 import { currentReverseIdxState, historyDataListState } from 'recoil/history';
 import { userListState } from 'recoil/project';

--- a/client/src/components/molecules/HistoryWindow/index.tsx
+++ b/client/src/components/molecules/HistoryWindow/index.tsx
@@ -4,28 +4,28 @@ import { MouseEvent } from 'react';
 import useDragBackground from 'hooks/useDragBackground';
 import { IHistoryData } from 'types/history';
 import { useRecoilValue } from 'recoil';
-import { historyDataListState } from 'recoil/history';
+import { currentReverseIdxState, historyDataListState } from 'recoil/history';
 import { userListState } from 'recoil/project';
 
 interface IProps {
-  onClick: (historyData: IHistoryData, idx: number) => (event: MouseEvent) => void;
-  currentHistoryData: IHistoryData | null;
+  onClick: (idx: number) => (event: MouseEvent) => void;
 }
 
-const HistoryWindow: React.FC<IProps> = ({ onClick, currentHistoryData }) => {
+const HistoryWindow: React.FC<IProps> = ({ onClick }) => {
   const { containerRef, dragRef } = useDragBackground();
   const historyDataList = useRecoilValue(historyDataListState);
   const userList = useRecoilValue(userListState);
-  const isSelected = (data: IHistoryData): boolean => currentHistoryData !== null && data.historyId === currentHistoryData.historyId;
+  const currentReverseIdx = useRecoilValue(currentReverseIdxState);
+  const isSelected = (idx: number): boolean => idx === currentReverseIdx;
 
   return (
     <Wrapper ref={containerRef} className='background'>
-      {historyDataList.length && userList && currentHistoryData
+      {historyDataList.length && userList
         ? historyDataList.map((historyData, idx) => (
             <IconWrapper
               key={historyData.historyId}
-              onClick={onClick(historyData, idx)}
-              isSelected={isSelected(historyData)}
+              onClick={onClick(idx - historyDataList.length)}
+              isSelected={isSelected(idx - historyDataList.length)}
               color={userList[historyData.user].color}
             >
               <UserIcon user={userList[historyData.user]} cursor='pointer' />

--- a/client/src/components/molecules/HistoryWindow/style.tsx
+++ b/client/src/components/molecules/HistoryWindow/style.tsx
@@ -9,7 +9,7 @@ export const Wrapper = styled.div`
   width: 100%;
   height: 80px;
   ${({ theme }) => theme.flex.row}
-  overflow: scroll;
+  overflow: hidden;
   gap: 1rem;
   align-items: center;
   font-size: 2rem;

--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -1,14 +1,15 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { Node, PriorityIcon, UserIcon } from 'components/atoms';
 import { Path, TempNode } from 'components/molecules';
-import { TCoord, TRect, getCurrentCoord, getGap, getType, calcRect, Levels } from 'utils/helpers';
+import { ITaskFilters } from 'components/organisms/MindmapTree';
+import { NodeContainer, ChildContainer } from './style';
 import { getNextMapState, mindmapState, TEMP_NODE_ID } from 'recoil/mindmap';
 import { selectedNodeIdState } from 'recoil/node';
-import { NodeContainer, ChildContainer } from './style';
+import { currentHistoryNodeIdState } from 'recoil/history';
 import useHistoryEmitter from 'hooks/useHistoryEmitter';
+import { TCoord, TRect, getCurrentCoord, getGap, getType, calcRect, Levels } from 'utils/helpers';
 import { IMindmapData, IMindNode, IMindNodes } from 'types/mindmap';
-import { ITaskFilters } from 'components/organisms/MindmapTree';
 import { IUser } from 'types/user';
 
 interface ITreeProps {
@@ -73,6 +74,9 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId
 
   const [selectedNodeId, setSelectedNodeId] = useRecoilState(selectedNodeIdState);
   const isSelected = selectedNodeId === nodeId;
+
+  const currentHistoryNodeId = useRecoilValue(currentHistoryNodeIdState);
+  const isHistorySelected = currentHistoryNodeId === nodeId;
 
   const [coord, setCoord] = useState<TCoord | null>(null);
   const [rect, setRect] = useState<TRect | null>(null);
@@ -148,7 +152,7 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId
           ref={nodeRef}
           id={nodeId.toString()}
           level={level}
-          isSelected={isSelected}
+          isSelected={isSelected || isHistorySelected}
           isFiltered={isFilteredTask}
           className='node mindmap-area'
           status={status}

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -3,8 +3,7 @@ import useLinkClick from 'hooks/useLinkClick';
 import { Wrapper, UpperDiv } from './style';
 import { Title } from 'components/atoms';
 import { HistoryLog, IconButton, PlayController, HistoryWindow } from 'components/molecules';
-import { useCallback, useEffect, useState } from 'react';
-import { IHistoryData } from 'types/history';
+import { useCallback } from 'react';
 import { useResetRecoilState, useRecoilValue } from 'recoil';
 import { currentReverseIdxState, historyDataListState } from 'recoil/history';
 import { historyMapDataState } from 'recoil/mindmap';
@@ -30,20 +29,12 @@ const HistoryBar: React.FC = () => {
 
   const handleHistoryClick = useCallback(
     (idx: number) => () => {
-      if (!currentReverseIdx) return handleCloseHistoryBtnClick();
       if (currentReverseIdx === idx) return;
 
-      const isForward = currentReverseIdx < idx;
-
-      historyController({ from: currentReverseIdx, to: idx, isForward });
+      historyController({ fromIdx: currentReverseIdx, toIdx: idx });
     },
-    [currentReverseIdx]
+    [currentReverseIdx, historyController]
   );
-
-  // useEffect(() => {
-  //   if (!historyDataList.length || currentReverseIdx) return;
-  //   setcurrentReverseIdx(-1);
-  // }, [historyDataList]);
 
   return (
     <Wrapper>

--- a/client/src/hooks/useHistoryController/index.ts
+++ b/client/src/hooks/useHistoryController/index.ts
@@ -9,25 +9,36 @@ interface IHistoryControllerProps {
   toIdx: number;
 }
 
+interface IHandleMoveProps {
+  historyData: IHistoryData;
+  idx: number;
+  fromIdx: number;
+}
+
 const useHistoryController = () => {
   const [historyMapData, setHistoryMapData] = useRecoilState(historyMapDataState);
   const [historyDataList, setHistoryDataList] = useRecoilState(historyDataListState);
   const setCurrentReverseIdx = useSetRecoilState(currentReverseIdxState);
 
-  const handleMoveForward = (historyData: IHistoryData, idx: number, fromIdx: number) => {
+  const handleMoveForward = ({ historyData, idx, fromIdx }: IHandleMoveProps) => {
     const params = { historyData, isForward: true, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
     restoreHistory(params);
     setCurrentReverseIdx(fromIdx + idx);
   };
 
-  const handleMoveBackward = (historyData: IHistoryData, idx: number, fromIdx: number) => {
+  const handleMoveBackward = ({ historyData, idx, fromIdx }: IHandleMoveProps) => {
     const params = { historyData, isForward: false, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
     restoreHistory(params);
 
     setCurrentReverseIdx(fromIdx - idx);
   };
 
-  const historyController = ({ fromIdx, toIdx }: IHistoryControllerProps) => {
+  const wait = (time: number, func: (props: IHandleMoveProps) => void, props: IHandleMoveProps) =>
+    new Promise((resolve) => {
+      setTimeout(() => resolve(func(props)), time);
+    });
+
+  const historyController = async ({ fromIdx, toIdx }: IHistoryControllerProps) => {
     const isForward = fromIdx < toIdx;
 
     if (isForward) {
@@ -36,7 +47,10 @@ const useHistoryController = () => {
 
       const stopHistories = historyDataList.slice(from, to);
 
-      stopHistories.forEach((historyData, idx) => handleMoveForward(historyData, idx, fromIdx + 1));
+      await stopHistories.reduce(async (lastPromise, historyData, idx) => {
+        await lastPromise;
+        await wait(700, handleMoveForward, { historyData, idx, fromIdx: fromIdx + 1 });
+      }, Promise.resolve());
     } else {
       const from = toIdx + 1;
       const to = fromIdx + 1 !== 0 ? fromIdx + 1 : undefined;
@@ -44,7 +58,10 @@ const useHistoryController = () => {
       const stopHistories = historyDataList.slice(from, to);
       stopHistories.reverse();
 
-      stopHistories.forEach((historyData, idx) => handleMoveBackward(historyData, idx, fromIdx - 1));
+      await stopHistories.reduce(async (lastPromise, historyData, idx) => {
+        await lastPromise;
+        await wait(700, handleMoveBackward, { historyData, idx, fromIdx: fromIdx - 1 });
+      }, Promise.resolve());
     }
   };
 

--- a/client/src/hooks/useHistoryController/index.ts
+++ b/client/src/hooks/useHistoryController/index.ts
@@ -1,24 +1,51 @@
-import { useRef } from 'react';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { currentReverseIdxState, historyDataListState } from 'recoil/history';
 import { historyMapDataState } from 'recoil/mindmap';
+import { IHistoryData } from 'types/history';
+import { restoreHistory } from 'utils/historyHandler';
 
 interface IHistoryControllerProps {
-  from: number;
-  to: number;
-  isForward: boolean;
+  fromIdx: number;
+  toIdx: number;
 }
 
 const useHistoryController = () => {
   const [historyMapData, setHistoryMapData] = useRecoilState(historyMapDataState);
+  const [historyDataList, setHistoryDataList] = useRecoilState(historyDataListState);
+  const setCurrentReverseIdx = useSetRecoilState(currentReverseIdxState);
 
-  const handleMoveForward = () => {};
+  const handleMoveForward = (historyData: IHistoryData, idx: number, fromIdx: number) => {
+    const params = { historyData, isForward: true, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
+    restoreHistory(params);
+    setCurrentReverseIdx(fromIdx + idx);
+  };
 
-  const handleMoveBackward = () => {};
+  const handleMoveBackward = (historyData: IHistoryData, idx: number, fromIdx: number) => {
+    const params = { historyData, isForward: false, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
+    restoreHistory(params);
 
-  const historyController = ({ from, to, isForward }: IHistoryControllerProps) => {
-    // const targetData = isForward ? historyData : currentHistoryData;
-    // const params = { historyData: targetData, isForward, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
-    // restoreHistory(params);
+    setCurrentReverseIdx(fromIdx - idx);
+  };
+
+  const historyController = ({ fromIdx, toIdx }: IHistoryControllerProps) => {
+    const isForward = fromIdx < toIdx;
+
+    if (isForward) {
+      const from = fromIdx + 1;
+      const to = toIdx + 1 !== 0 ? toIdx + 1 : undefined;
+
+      const stopHistories = historyDataList.slice(from, to);
+
+      stopHistories.forEach((historyData, idx) => handleMoveForward(historyData, idx, fromIdx + 1));
+    } else {
+      const from = toIdx + 1;
+      const to = fromIdx + 1 !== 0 ? fromIdx + 1 : undefined;
+
+      const stopHistories = historyDataList.slice(from, to);
+      stopHistories.reverse();
+
+      stopHistories.forEach((historyData, idx) => handleMoveBackward(historyData, idx, fromIdx - 1));
+    }
   };
 
   return historyController;

--- a/client/src/hooks/useHistoryController/index.ts
+++ b/client/src/hooks/useHistoryController/index.ts
@@ -1,40 +1,27 @@
-import { historyHandler } from 'hooks/useHistoryReceiver';
 import { useRef } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { historyDataListState } from 'recoil/history';
-import { mindmapState } from 'recoil/mindmap';
+import { useRecoilState } from 'recoil';
+import { historyMapDataState } from 'recoil/mindmap';
+
+interface IHistoryControllerProps {
+  from: number;
+  to: number;
+  isForward: boolean;
+}
 
 const useHistoryController = () => {
-  const [mindmap, setMindmap] = useRecoilState(mindmapState);
-  // const { history } = useRecoilValue(historyState);
-  const historyIdxRef = useRef(history.length - 1);
-  const lastMindmapRef = useRef(mindmap);
+  const [historyMapData, setHistoryMapData] = useRecoilState(historyMapDataState);
 
-  const handleMoveForward = () => {
-    if (historyIdxRef.current < history.length - 2) {
-      const nextIdx = historyIdxRef.current + 1;
-      // historyHandler({ setMindmap, historyData: history[nextIdx], isForward: true });
-      historyIdxRef.current = nextIdx;
-    }
+  const handleMoveForward = () => {};
+
+  const handleMoveBackward = () => {};
+
+  const historyController = ({ from, to, isForward }: IHistoryControllerProps) => {
+    // const targetData = isForward ? historyData : currentHistoryData;
+    // const params = { historyData: targetData, isForward, setHistoryMapData, setHistoryDataList, historyDataList, historyMapData };
+    // restoreHistory(params);
   };
 
-  const handleMoveBackward = () => {
-    if (historyIdxRef.current > 0) {
-      const prevIdx = historyIdxRef.current - 1;
-      // historyHandler({ setMindmap, historyData: history[prevIdx], isForward: true });
-      historyIdxRef.current = prevIdx;
-    }
-  };
-
-  const handleControlEnd = () => {
-    setMindmap(lastMindmapRef.current);
-  };
-
-  return {
-    handleMoveForward,
-    handleMoveBackward,
-    handleControlEnd,
-  };
+  return historyController;
 };
 
 export default useHistoryController;

--- a/client/src/hooks/useLog/index.tsx
+++ b/client/src/hooks/useLog/index.tsx
@@ -1,5 +1,4 @@
 import { useRecoilValue } from 'recoil';
-import { historyMapState } from 'recoil/mindmap';
 import { labelListState, sprintListState, userListState } from 'recoil/project';
 import { TAddNodeData, TDeleteNodeData, TUpdateNodeContent, TUpdateTaskInformation, THistoryEventType } from 'types/event';
 import { IHistoryData } from 'types/history';
@@ -24,7 +23,6 @@ export const useLog = () => {
   const userList = useRecoilValue(userListState);
   const labelList = useRecoilValue(labelListState);
   const sprintList = useRecoilValue(sprintListState);
-  const historyMap = useRecoilValue(historyMapState);
 
   const getLog = ({ type, data: { dataTo, dataFrom } }: IHistoryData) => {
     return convertToDescription[type]({ dataTo, dataFrom } as IConvertParams);

--- a/client/src/hooks/useLog/index.tsx
+++ b/client/src/hooks/useLog/index.tsx
@@ -1,0 +1,99 @@
+import { useRecoilValue } from 'recoil';
+import { historyMapState } from 'recoil/mindmap';
+import { labelListState, sprintListState, userListState } from 'recoil/project';
+import { TAddNodeData, TDeleteNodeData, TUpdateNodeContent, TUpdateTaskInformation, THistoryEventType } from 'types/event';
+import { IHistoryData } from 'types/history';
+
+type TConvertData = TAddNodeData | TUpdateNodeContent | TUpdateTaskInformation | TDeleteNodeData;
+
+interface IConvertParams {
+  dataTo?: TConvertData;
+  dataFrom?: TConvertData;
+}
+
+type TConvertToDescription = {
+  [key in THistoryEventType]: ({ dataFrom, dataTo }: IConvertParams) => string;
+};
+
+interface IConvertTaskInformationParams {
+  dataTo?: TUpdateTaskInformation;
+  dataFrom?: TUpdateTaskInformation;
+}
+
+export const useLog = () => {
+  const userList = useRecoilValue(userListState);
+  const labelList = useRecoilValue(labelListState);
+  const sprintList = useRecoilValue(sprintListState);
+  const historyMap = useRecoilValue(historyMapState);
+
+  const getLog = ({ type, data: { dataTo, dataFrom } }: IHistoryData) => {
+    return convertToDescription[type]({ dataTo, dataFrom } as IConvertParams);
+  };
+
+  const convertToDescription: TConvertToDescription = {
+    ADD_NODE: ({ dataTo }) => `${(dataTo as TAddNodeData).content} 노드가 생성되었습니다.`,
+    DELETE_NODE: ({ dataTo }) => `${(dataTo as TDeleteNodeData).content} 노드가 삭제되었습니다.`,
+    MOVE_NODE: ({}) => `노드 위치가 변경되었습니다.`,
+    UPDATE_NODE_PARENT: () => `노드 레벨이 변경되었습니다.`,
+    UPDATE_NODE_SIBLING: () => `노드 순서가 변경되었습니다.`,
+    UPDATE_NODE_CONTENT: ({ dataFrom, dataTo }) =>
+      `노드 내용이 '${(dataFrom as TUpdateNodeContent).content}'에서 '${(dataTo as TUpdateNodeContent)!.content}'로 변경되었습니다.`,
+    UPDATE_TASK_INFORMATION: (data) => {
+      const { dataFrom, dataTo } = data as IConvertTaskInformationParams;
+      const description = convertTaskInformation({ dataFrom, dataTo });
+      return `노드의 상세정보가 변경되었습니다. ${description}`;
+    },
+  };
+
+  const convertTaskInformation = ({ dataFrom, dataTo }: IConvertTaskInformationParams) => {
+    const changedTask = Object.keys(dataFrom!.changed)[0];
+    let [task, before, after]: [string, string, string] = ['', '', ''];
+
+    switch (changedTask) {
+      case 'assigneeId':
+        task = ' 담당자 : ';
+        before = `${dataFrom!.changed[changedTask] ? userList[dataFrom!.changed[changedTask]!].name : '지정하지 않음'}`;
+        after = `${dataTo!.changed[changedTask] ? userList[dataTo!.changed[changedTask]!].name : '지정하지 않음'}`;
+        break;
+      case 'labels':
+        task = ' 라벨 : ';
+        before = `${dataFrom!.changed[changedTask]!.map((labelId) => labelList[labelId])}`;
+        after = `${dataTo!.changed[changedTask]!.map((labelId) => labelList[labelId])}`;
+        break;
+      case 'priority':
+        task = ' 중요도 : ';
+        before = `${dataFrom!.changed[changedTask] ?? '지정하지 않음'}`;
+        after = `${dataTo!.changed[changedTask] ?? '지정하지 않음'}`;
+        break;
+      case 'dueDate':
+        task = ' 마감 날짜 : ';
+        before = `${dataFrom!.changed[changedTask] ?? '지정하지 않음'}`;
+        after = `${dataTo!.changed[changedTask] ?? '지정하지 않음'}`;
+        break;
+      case 'estimatedTime':
+        task = ' 예상 소요 시간 : ';
+        before = `${dataFrom!.changed[changedTask] ?? '지정하지 않음'}`;
+        after = `${dataTo!.changed[changedTask] ?? '지정하지 않음'}`;
+        break;
+      case 'status':
+        task = ' 진행 상태 : ';
+        before = `${dataFrom!.changed[changedTask] ?? '지정하지 않음'}`;
+        after = `${dataTo!.changed[changedTask] ?? '지정하지 않음'}`;
+        break;
+      case 'finishedTime':
+        task = ' 마감 시간 : ';
+        before = `${dataFrom!.changed[changedTask] ?? '지정하지 않음'}`;
+        after = `${dataTo!.changed[changedTask] ?? '지정하지 않음'}`;
+        break;
+      case 'sprintId':
+        task = ' 스프린트 : ';
+        before = `${dataFrom!.changed[changedTask] ? sprintList[dataFrom!.changed[changedTask]!].name : '지정하지 않음'}`;
+        after = `${dataTo!.changed[changedTask] ? sprintList[dataTo!.changed[changedTask]!].name : '지정하지 않음'}`;
+        break;
+    }
+
+    return `${task}${before} -> ${after}`;
+  };
+
+  return getLog;
+};

--- a/client/src/recoil/history/index.ts
+++ b/client/src/recoil/history/index.ts
@@ -10,3 +10,5 @@ export const farthestHistoryIdState = atom<string | undefined>({
   key: 'farthestHistoryAtom',
   default: undefined,
 });
+
+export const currentReverseIdxState = atom<number>({ key: 'currentReverseIdxAtom', default: -1 });

--- a/client/src/recoil/history/index.ts
+++ b/client/src/recoil/history/index.ts
@@ -1,5 +1,8 @@
-import { atom } from 'recoil';
+import { atom, selector } from 'recoil';
+import { TAddNodeData, TDeleteNodeData, THistoryEventData, TUpdateNodeParent } from 'types/event';
 import { IHistoryData } from 'types/history';
+
+const CANNOT_FIND_NODE_ID = -3;
 
 export const historyDataListState = atom<IHistoryData[]>({
   key: 'historyDataListAtom',
@@ -12,3 +15,31 @@ export const farthestHistoryIdState = atom<string | undefined>({
 });
 
 export const currentReverseIdxState = atom<number>({ key: 'currentReverseIdxAtom', default: -1 });
+
+export const currentHistoryNodeIdState = selector({
+  key: 'currentHistoryNodeIdState',
+  get: ({ get }) => {
+    const currentReverseIdx = get(currentReverseIdxState);
+    const historyDataList = get(historyDataListState);
+
+    const currentNodeData = historyDataList.at(currentReverseIdx);
+    switch (currentNodeData?.type) {
+      case 'ADD_NODE':
+        return (currentNodeData.data.dataTo! as TAddNodeData).nodeId;
+      case 'DELETE_NODE':
+        return (currentNodeData.data.dataFrom! as TDeleteNodeData).nodeId;
+      case 'MOVE_NODE':
+        return currentNodeData.data.nodeFrom! as THistoryEventData;
+      case 'UPDATE_NODE_PARENT':
+        return (currentNodeData.data.dataFrom! as TUpdateNodeParent).nodeId;
+      case 'UPDATE_NODE_SIBLING':
+        return currentNodeData.data.nodeFrom! as THistoryEventData;
+      case 'UPDATE_NODE_CONTENT':
+        return currentNodeData.data.nodeFrom! as THistoryEventData;
+      case 'UPDATE_TASK_INFORMATION':
+        return currentNodeData.data.nodeFrom! as THistoryEventData;
+      default:
+        return CANNOT_FIND_NODE_ID;
+    }
+  },
+});

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -139,7 +139,7 @@ interface IDeleteNodeParams {
   historyDataList?: IHistoryData[];
 }
 
-const deleteNode = ({ historyData, historyMap, historyDataList, setHistoryDataList }: IDeleteNodeParams) => {
+const deleteNode = ({ historyData, historyMap, setHistoryDataList }: IDeleteNodeParams) => {
   const parentId = historyData.data.nodeFrom!;
   const parent = historyMap.get(parentId)!;
 

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -76,10 +76,11 @@ export const restoreHistory = (params: IParams) => {
         updateTaskInformation({ id: historyData.data.nodeFrom!, data: historyData.data.dataTo as TUpdateTaskInformation, historyMap });
       else updateTaskInformation({ id: historyData.data.nodeFrom!, data: historyData.data.dataFrom as TUpdateTaskInformation, historyMap });
       break;
+    default:
+      return;
   }
 
   const mapData = getNextMapState(historyMapData);
-
   setHistoryMapData(mapData);
 };
 
@@ -145,16 +146,20 @@ const deleteNode = ({ historyData, historyMap, historyDataList, setHistoryDataLi
   const childId = historyData.data.dataFrom
     ? (historyData.data.dataFrom as TDeleteNodeData).nodeId
     : parent.children[parent.children.length - 1];
-  const newChildren = historyData.data.dataFrom ? parent.children.filter((cid) => cid !== childId) : parent.children.slice(0, -1);
 
+  const newChildren = historyData.data.dataFrom ? parent.children.filter((cid) => cid !== childId) : parent.children.slice(0, -1);
   historyMap.set(parentId, { ...parent, children: newChildren });
+
   if (historyData.data.dataTo && !(historyData.data.dataTo! as TAddNodeData).nodeId) {
     const newDataTo = { ...historyData.data.dataTo, nodeId: childId };
     const newHistory = { ...historyData!, data: { ...historyData.data, dataTo: newDataTo } };
-    const newList = [...historyDataList!];
-    const index = newList.findIndex((d) => d.historyId === newHistory.historyId);
-    newList.splice(index, 1, newHistory as IHistoryData);
-    setHistoryDataList!(newList);
+
+    setHistoryDataList!((prevList) => {
+      const newList = [...prevList!];
+      const index = newList.findIndex((d) => d.historyId === newHistory.historyId);
+      newList.splice(index, 1, newHistory as IHistoryData);
+      return newList;
+    });
   }
 };
 


### PR DESCRIPTION
## 📑 제목
히스토리 리스트에서 특정 원을 클릭하면 현재 보고 있는 시점에서 클릭한 원까지의 변화 과정을 보여주며 이동한다.
현재 히스토리에 해당하는 노드는 하이라이트 되어 보여진다.
## 📎 관련 이슈
- #66 
- #124 
## ✔️ 셀프 체크리스트
- [x] 아이콘 클릭 시 그 아이콘 까지 변경사항 마인드맵 출력 구현
## 💬 작업 내용
- 히스토리 로그 상세화
- 특정 히스토리 클릭 시 순차적으로 변화하며 이동하는 기능
## 🚧 PR 특이 사항
- 노드 상세화 content를 추가하는 작업 필요
- currentHistoryData를 로컬 state로 관리하는 방식에서 currentReverseIdx를 recoil state로 관리하는 방식으로 수정
- reduce를 통해 순차적 비동기 작업을 하기 때문에 중간에 멈추지 못함. UX적으로 불완전.. 개선 필요.
- 선택된 히스토리 노드를 하이라이트 하는 기능에서 ADD_NODE를 역연산 하는 과정에서는 nodeId를 특정할 수 없기 때문에 하이라이트 불가. 논의해보고 되돌릴지 결정 필요.
## 🕰 실제 소요 시간
- 6h