### PR TITLE
도커, nginx https 세팅

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,9 +36,12 @@ services:
     build:
       context: ./nginx
     volumes:
+      - ${SSL_FULLCHAIN_DIR}:/ssl/fullchain.pem;
+      - ${SSL_PRIVKEY_DIR}:/ssl/privkey.pem;
       - share:/usr/nginx/html
     ports:
       - 80:80
+      - 443:443
     restart: always
 
   mysql:

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -4,6 +4,19 @@ upstream server {
 
 server {
   listen 80;
+  server_name agilestorming.live;
+
+  location / {
+    return 301 https://$server_name$request_uri;
+  }
+}
+
+server {
+  listen 443 ssl http2;
+  server_name agilestorming.live;
+
+  ssl_certificate /ssl/fullchain.pem;
+  ssl_certificate_key /ssl/privkey.pem;
 
   location / {
     root /usr/nginx/html;


### PR DESCRIPTION
## 📑 제목
🔧 도커, nginx https 세팅

## 📎 관련 이슈
#130 

## ✔️ 셀프 체크리스트
 https 로 접속한다.
 클립보드 공유 활성화

## 💬 작업 내용
Certbot 인증서 받기
경로로 ssl 키 복사
443 포트 포워딩

![image](https://user-images.githubusercontent.com/73219421/142831854-fff420dc-40c1-4bb4-8cad-978617f31ca2.png)


## 🚧 PR 특이 사항
pm2는 .env 이슈로 나중에 하기로 했습니다.
보안을 더 강화할 수 방법이 있더군요. 시간이 남으면 도전해봅시다

## 🕰 실제 소요 시간
4h