### PR TITLE
히스토리 직접 클릭과 재생 버튼 클릭 사이 상호작용 제어 및 재생 버튼 종료 시 초기화

### DIFF
--- a/client/src/components/atoms/Node/index.tsx
+++ b/client/src/components/atoms/Node/index.tsx
@@ -1,4 +1,3 @@
-import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { TStatus } from 'types/event';
 import { Levels, levelToIdx } from 'utils/helpers';

--- a/client/src/components/molecules/PlayController/index.tsx
+++ b/client/src/components/molecules/PlayController/index.tsx
@@ -15,19 +15,19 @@ const PlayController = () => {
   const handleBackwardBtnClick = useCallback(() => {
     if (isCalculating) return;
     getOldestHistory(currentReverseIdx);
-  }, [isCalculating]);
+  }, [isCalculating, getOldestHistory]);
 
   const handleForwardBtnClick = useCallback(() => {
     if (isCalculating) return;
     getYoungestHistory(currentReverseIdx);
-  }, [isCalculating]);
+  }, [isCalculating, getYoungestHistory]);
 
   const handlePlayBtnClick = useCallback(() => {
     if (isCalculating) return;
     setIsCalculating(true);
     playHistories(currentReverseIdx, setIsPlaying);
     setIsPlaying(true);
-  }, [isCalculating, currentReverseIdx]);
+  }, [isCalculating, currentReverseIdx, playHistories]);
 
   const handleStopBtnClick = () => {
     setIsCalculating(false);

--- a/client/src/components/molecules/PlayController/index.tsx
+++ b/client/src/components/molecules/PlayController/index.tsx
@@ -25,7 +25,7 @@ const PlayController = () => {
   const handlePlayBtnClick = useCallback(() => {
     if (isCalculating) return;
     setIsCalculating(true);
-    playHistories(currentReverseIdx);
+    playHistories(currentReverseIdx, setIsPlaying);
     setIsPlaying(true);
   }, [isCalculating, currentReverseIdx]);
 

--- a/client/src/components/molecules/PlayController/index.tsx
+++ b/client/src/components/molecules/PlayController/index.tsx
@@ -1,8 +1,8 @@
 import useHistoryController from 'hooks/useHistoryController';
 import { backwardBtn, playBtn, forwardBtn, pauseBtn } from 'img';
-import { useState } from 'react';
-import { useRecoilValue } from 'recoil';
-import { currentReverseIdxState } from 'recoil/history';
+import { useCallback, useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentReverseIdxState, isHistoryCalculatingState } from 'recoil/history';
 import { IconButton } from '..';
 import { Wrapper } from './style';
 
@@ -10,14 +10,27 @@ const PlayController = () => {
   const currentReverseIdx = useRecoilValue(currentReverseIdxState);
   const { getOldestHistory, getYoungestHistory, playHistories, stopHistories } = useHistoryController();
   const [isPlaying, setIsPlaying] = useState(false);
+  const [isCalculating, setIsCalculating] = useRecoilState(isHistoryCalculatingState);
 
-  const handleBackwardBtnClick = () => getOldestHistory(currentReverseIdx);
-  const handleForwardBtnClick = () => getYoungestHistory(currentReverseIdx);
-  const handlePlayBtnClick = () => {
+  const handleBackwardBtnClick = useCallback(() => {
+    if (isCalculating) return;
+    getOldestHistory(currentReverseIdx);
+  }, [isCalculating]);
+
+  const handleForwardBtnClick = useCallback(() => {
+    if (isCalculating) return;
+    getYoungestHistory(currentReverseIdx);
+  }, [isCalculating]);
+
+  const handlePlayBtnClick = useCallback(() => {
+    if (isCalculating) return;
+    setIsCalculating(true);
     playHistories(currentReverseIdx);
     setIsPlaying(true);
-  };
+  }, [isCalculating, currentReverseIdx]);
+
   const handleStopBtnClick = () => {
+    setIsCalculating(false);
     stopHistories();
     setIsPlaying(false);
   };

--- a/client/src/components/organisms/HistoryBar/index.tsx
+++ b/client/src/components/organisms/HistoryBar/index.tsx
@@ -1,8 +1,8 @@
 import { Wrapper } from './style';
 import { HistoryLog, HistoryWindow } from 'components/molecules';
-import { useCallback, useRef } from 'react';
-import { useRecoilValue } from 'recoil';
-import { currentReverseIdxState, historyDataListState } from 'recoil/history';
+import { useCallback } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { currentReverseIdxState, historyDataListState, isHistoryCalculatingState } from 'recoil/history';
 import useHistoryController from 'hooks/useHistoryController';
 import { HistoryHeader } from '..';
 
@@ -12,18 +12,20 @@ const HistoryBar: React.FC = () => {
 
   const { historyController } = useHistoryController();
 
-  const isCalculating = useRef(false);
+  const [isCalculating, setIsCalculating] = useRecoilState(isHistoryCalculatingState);
 
   const handleHistoryClick = useCallback(
     (idx: number) => async () => {
-      if (currentReverseIdx === idx || isCalculating.current) return;
+      if (currentReverseIdx === idx || isCalculating) return;
 
-      isCalculating.current = true;
+      setIsCalculating(true);
       const controller = historyController({ fromIdx: currentReverseIdx, toIdx: idx });
 
-      controller.finally(() => (isCalculating.current = false));
+      controller.finally(() => {
+        setIsCalculating(false);
+      });
     },
-    [currentReverseIdx, historyController]
+    [currentReverseIdx, historyController, isCalculating]
   );
 
   return (

--- a/client/src/components/organisms/HistoryHeader/index.tsx
+++ b/client/src/components/organisms/HistoryHeader/index.tsx
@@ -28,7 +28,7 @@ const HistoryHeader = () => {
 
   return (
     <Wrapper>
-      <Range type='range' onMouseUp={changeHistoryMovingSpeed} max='70' />
+      <Range type='range' onMouseUp={changeHistoryMovingSpeed} max='70' defaultValue='35' />
       <PlayController />
       <RightWrapper>
         <IconButton imgSrc={whiteCloseBtn} onClick={handleCloseHistoryBtnClick} altText='히스토리 닫기 버튼' />

--- a/client/src/hooks/useHistoryController/index.ts
+++ b/client/src/hooks/useHistoryController/index.ts
@@ -53,7 +53,7 @@ const useHistoryController = () => {
       restoreHistory(params);
       setCurrentReverseIdx(fromIdx + idx);
     },
-    [historyDataList]
+    [historyDataList, historyMapData]
   );
 
   const handleMoveBackward = useCallback(
@@ -62,7 +62,7 @@ const useHistoryController = () => {
       restoreHistory(params);
       setCurrentReverseIdx(fromIdx - idx);
     },
-    [historyDataList]
+    [historyDataList, historyMapData]
   );
 
   const historyController = useCallback(
@@ -78,7 +78,7 @@ const useHistoryController = () => {
         return restoreAsyncHistory(stopHistories, handleMoveBackward, fromIdx - 1, time);
       }
     },
-    [handleMoveForward, handleMoveBackward, time]
+    [handleMoveForward, handleMoveBackward, time, historyDataList]
   );
 
   const getOldestHistory = useCallback(
@@ -89,7 +89,7 @@ const useHistoryController = () => {
 
       stopHistories.forEach((historyData, idx) => handleMoveBackward({ historyData, idx, fromIdx: fromIdx - 1 }));
     },
-    [handleMoveBackward]
+    [historyDataList, handleMoveBackward]
   );
 
   const getYoungestHistory = useCallback(
@@ -99,7 +99,7 @@ const useHistoryController = () => {
 
       stopHistories.forEach((historyData, idx) => handleMoveForward({ historyData, idx, fromIdx: fromIdx + 1 }));
     },
-    [handleMoveForward]
+    [historyDataList, handleMoveForward]
   );
 
   const playHistories = useCallback(
@@ -119,7 +119,7 @@ const useHistoryController = () => {
         idx++;
       }, time);
     },
-    [historyDataList, intervalId.current, handleMoveForward, time]
+    [historyDataList, intervalId.current, handleMoveForward, time, setIsCalculating]
   );
 
   const stopHistories = useCallback(() => {

--- a/client/src/hooks/useHistoryController/index.ts
+++ b/client/src/hooks/useHistoryController/index.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-import { currentReverseIdxState, historyDataListState, historyMovingSpeedState } from 'recoil/history';
+import { currentReverseIdxState, historyDataListState, historyMovingSpeedState, isHistoryCalculatingState } from 'recoil/history';
 import { historyMapDataState } from 'recoil/mindmap';
 import { IHistoryData } from 'types/history';
 import { restoreHistory } from 'utils/historyHandler';
@@ -43,6 +43,7 @@ const useHistoryController = () => {
   const [historyMapData, setHistoryMapData] = useRecoilState(historyMapDataState);
   const [historyDataList, setHistoryDataList] = useRecoilState(historyDataListState);
   const setCurrentReverseIdx = useSetRecoilState(currentReverseIdxState);
+  const setIsCalculating = useSetRecoilState(isHistoryCalculatingState);
   const time = useRecoilValue(historyMovingSpeedState);
   const intervalId = useRef<NodeJS.Timer | null>(null);
 
@@ -102,11 +103,16 @@ const useHistoryController = () => {
   );
 
   const playHistories = useCallback(
-    (fromIdx: number) => {
+    (fromIdx: number, setIsPlaying: React.Dispatch<React.SetStateAction<boolean>>) => {
       let idx = 1;
 
       intervalId.current = setInterval(() => {
-        if (fromIdx + idx === 0) return clearInterval(intervalId.current!);
+        if (fromIdx + idx === 0) {
+          setIsPlaying(false);
+          setIsCalculating(false);
+          clearInterval(intervalId.current!);
+          return;
+        }
 
         const historyData = historyDataList.at(fromIdx + idx)!;
         handleMoveForward({ historyData, idx, fromIdx });

--- a/client/src/hooks/useNewHistoryData/index.tsx
+++ b/client/src/hooks/useNewHistoryData/index.tsx
@@ -20,8 +20,8 @@ const useNewHistoryData = () => {
         const historyRowData = await API.history.get(projectId, rangeFrom);
         if (!historyRowData.length) return showMessage('더이상 가져올 히스토리가 없습니다.');
 
-        const historyData: IHistoryData[] = historyRowData.map((data: THistoryRowData) => parseHistory(data)).reverse();
-        setHistoryDataList((prev: IHistoryData[]) => [...historyData, ...prev]);
+        const newHistoryDataList: IHistoryData[] = historyRowData.map((data: THistoryRowData) => parseHistory(data)).reverse();
+        setHistoryDataList((prev: IHistoryData[]) => [...newHistoryDataList, ...prev]);
       } catch (err) {
         console.log(err);
         showMessage('히스토리를 가져오지 못했습니다.');
@@ -35,7 +35,7 @@ const useNewHistoryData = () => {
     const rangeFrom = '(' + currentHistoryData?.streamId;
 
     getNewHistoryData(rangeFrom);
-  }, [historyDataList]);
+  }, [historyDataList, getNewHistoryData]);
 
   return { getNewHistoryData, getMoreHistoryData };
 };

--- a/client/src/recoil/history/index.ts
+++ b/client/src/recoil/history/index.ts
@@ -48,3 +48,8 @@ export const historyMovingSpeedState = atom<number>({
   key: 'historyMovingSpeedAtom',
   default: 650,
 });
+
+export const isHistoryCalculatingState = atom<boolean>({
+  key: 'isHistoryIsCalculatingAtom',
+  default: false,
+});

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -155,7 +155,7 @@ const deleteNode = ({ historyData, historyMap, setHistoryDataList }: IDeleteNode
     const newHistory = { ...historyData!, data: { ...historyData.data, dataTo: newDataTo } };
 
     setHistoryDataList!((prevList) => {
-      const newList = [...prevList!];
+      const newList = [...prevList];
       const index = newList.findIndex((d) => d.historyId === newHistory.historyId);
       newList.splice(index, 1, newHistory as IHistoryData);
       return newList;


### PR DESCRIPTION
## 📑 제목
히스토리 직접 클릭과 재생 버튼 클릭 사이 상호작용 제어 및 재생 버튼 종료 시 초기화
## 📎 관련 이슈
- #143 
## ✔️ 셀프 체크리스트
- [x] 히스토리 클릭 동작과 재생 버튼 클릭 동작시 간섭하지 않도록 isCalculating recoil 상태로 관리한다.
- [x] 히스토리 재생 동작이 끝났을 때 다시 재생할 수 있도록 재생 버튼 모양으로 돌아온다.
## 💬 작업 내용
- isCalculating 리코일 관리
- 재생 버튼 동작 후 초기화
- 히스토리 관련 useCallback depency 정리
## 🚧 PR 특이 사항
더이상 버그가 없기를 기원합니다.
## 🕰 실제 소요 시간
3h