### PR TITLE
노드 삭제 시 히스토리에서 발생하는 버그를 해결

### DIFF
--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -20,7 +20,7 @@ interface ITreeProps {
   taskFilters: ITaskFilters;
   isFiltering: boolean;
   userList: Record<string, IUser>;
-  handleDeleteBtnClick: (props: IMindNode) => void;
+  handleDeleteBtnClick: (parentId: number, node: IMindNode) => void;
 }
 
 interface ICheckFilterProps {
@@ -177,7 +177,7 @@ const Tree: React.FC<ITreeProps> = ({
             {!!priority && <PriorityIcon priority={priority} />}
             {content}
           </Node>
-          {selectedNodeId === nodeId && <div onClick={handleDeleteBtnClick.bind(null, node)}>삭제하기</div>}
+          {!isRoot && isSelected && <div onClick={handleDeleteBtnClick.bind(null, parentId!, node)}>삭제하기</div>}
         </>
       )}
       <ChildContainer className='child-container'>

--- a/client/src/components/organisms/MindmapTree/index.tsx
+++ b/client/src/components/organisms/MindmapTree/index.tsx
@@ -26,9 +26,8 @@ const MindmapTree: React.FC<IProps> = ({ mindmapData }) => {
   };
   const isFiltering = !!Object.values(taskFilters).reduce((acc, filter) => (acc += filter ? filter : ''), '');
 
-  const handleDeleteBtnClick = (node: IMindNode) => {
-    const { nodeId } = node;
-    deleteNode({ nodeFrom: nodeId, dataFrom: node });
+  const handleDeleteBtnClick = (parentId: number, node: IMindNode) => {
+    deleteNode({ nodeFrom: parentId, dataFrom: node });
   };
 
   return (

--- a/client/src/hooks/useHistoryReceiver/index.ts
+++ b/client/src/hooks/useHistoryReceiver/index.ts
@@ -14,7 +14,7 @@ import {
 } from 'types/event';
 import { IHistoryData } from 'types/history';
 import { ILabel } from 'types/label';
-import { IMindmapData, IMindNodes } from 'types/mindmap';
+import { IMindmapData, IMindNode, IMindNodes } from 'types/mindmap';
 import { ISprint } from 'types/sprint';
 import { getChildLevel, levelToIdx, setTreeLevel } from 'utils/helpers';
 
@@ -68,7 +68,7 @@ const updateNodeParent = ({ nextMapState: { mindNodes }, oldParentId, newParentI
 export const historyHandler = ({ setMindmap, historyData }: IHistoryHandlerProps) => {
   const {
     type,
-    data: { nodeFrom, nodeTo, dataTo },
+    data: { nodeFrom, nodeTo, dataFrom, dataTo },
     newNodeId,
   } = historyData;
 
@@ -83,7 +83,10 @@ export const historyHandler = ({ setMindmap, historyData }: IHistoryHandlerProps
     case 'DELETE_NODE':
       setMindmap((prev) => {
         const nextMapState = getNextMapState(prev);
-        nextMapState.mindNodes.delete(nodeFrom!);
+        const parentNode = nextMapState.mindNodes.get(nodeFrom!)!;
+        const { nodeId } = dataFrom as IMindNode;
+        parentNode.children = parentNode.children.filter((childId) => childId !== nodeId);
+        nextMapState.mindNodes.delete(nodeId!);
         return nextMapState;
       });
       break;

--- a/client/src/hooks/useLog/index.tsx
+++ b/client/src/hooks/useLog/index.tsx
@@ -30,7 +30,7 @@ export const useLog = () => {
 
   const convertToDescription: TConvertToDescription = {
     ADD_NODE: ({ dataTo }) => `${(dataTo as TAddNodeData).content} 노드가 생성되었습니다.`,
-    DELETE_NODE: ({ dataTo }) => `${(dataTo as TDeleteNodeData).content} 노드가 삭제되었습니다.`,
+    DELETE_NODE: ({ dataFrom }) => `${(dataFrom as TDeleteNodeData).content} 노드가 삭제되었습니다.`,
     MOVE_NODE: ({}) => `노드 위치가 변경되었습니다.`,
     UPDATE_NODE_PARENT: () => `노드 레벨이 변경되었습니다.`,
     UPDATE_NODE_SIBLING: () => `노드 순서가 변경되었습니다.`,


### PR DESCRIPTION
## 📑 제목
노드 삭제 시 히스토리에서 발생하는 버그를 해결
## 📎 관련 이슈
- #142
## ✔️ 셀프 체크리스트
- [X] 오류 없이 히스토리바에서 ADD, DELETE 관련된 동작이 작동하는가
## 💬 작업 내용
소켓 이벤트 emit, receiver 버그 해결
히스토리 버그 해결
## 🚧 PR 특이 사항
깔끔하게 해결, 생각보다 별로 안걸렸다.
히스토리 문제인 줄 알았는데 emit, receive 로직 또한 오류가 있었다.
## 🕰 실제 소요 시간
1.5hr
