### PR TITLE
스프린트, 라벨 태스크 삭제 시 발생하는 버그를 해결한다.

### DIFF
--- a/client/src/components/molecules/Dropdown/index.tsx
+++ b/client/src/components/molecules/Dropdown/index.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { isNumber } from 'utils/form';
 import { DropdownList, StyledInput, TStyle, Wrapper } from './style';
 
 interface IProps extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -14,12 +15,16 @@ const Dropdown: React.FC<IProps> = ({ onValueChange, dropdownStyle = 'normal', i
   const [isOpen, setIsOpen] = useState(false);
 
   const handleClickDropdown = () => setIsOpen(!isOpen);
-  const handleClickItem = (id: string | number) => {
+  const handleClickItem = (id: string) => {
     if (activatorRef.current) {
       activatorRef.current.value = items[id];
     }
     if (onValueChange) {
-      onValueChange(id);
+      if (isNumber(id)) {
+        onValueChange(Number(id));
+      } else {
+        onValueChange(id);
+      }
     }
     setIsOpen(false);
   };

--- a/client/src/components/molecules/LabelIcon/index.tsx
+++ b/client/src/components/molecules/LabelIcon/index.tsx
@@ -9,6 +9,9 @@ export interface IProps {
 }
 
 const LabelIcon: React.FC<IProps> = ({ label, active = true, onClick = () => {} }) => {
+  if (!label) {
+    return null;
+  }
   return (
     <StyledLabelIcon label={label} active={active} onClick={onClick}>
       {label.name}

--- a/client/src/components/organisms/BacklogTable/TaskBacklog.tsx
+++ b/client/src/components/organisms/BacklogTable/TaskBacklog.tsx
@@ -20,7 +20,7 @@ const StoryBacklog: React.FC<IProps> = ({ task }) => {
   const taskRowData = [
     `${task.nodeId}`,
     `${task.content}`,
-    task.sprintId ? (
+    task.sprintId && sprintList[task.sprintId] ? (
       <>
         <ColorIcon key={task.nodeId} color={sprintList[task.sprintId].color} />
         {sprintList[task.sprintId].name}

--- a/client/src/components/organisms/NodeDetailWrapper/index.tsx
+++ b/client/src/components/organisms/NodeDetailWrapper/index.tsx
@@ -145,7 +145,7 @@ export const NodeDetailWrapper = () => {
                 id='sprint'
                 key={selectedNode.sprintId}
                 items={sprintDropdownItem}
-                placeholder={selectedNode.sprintId ? sprintList[selectedNode.sprintId].name : ''}
+                placeholder={selectedNode.sprintId && sprintList[selectedNode.sprintId] ? sprintList[selectedNode.sprintId].name : ''}
                 onValueChange={handleChangeNodeDetail('sprintId')}
                 dropdownStyle='small'
                 margin='0.1rem 0'

--- a/client/src/components/organisms/TaskCard/index.tsx
+++ b/client/src/components/organisms/TaskCard/index.tsx
@@ -32,7 +32,10 @@ const TaskCard: React.FC<IProps> = ({ taskInfo, setSelectedNodeIdTask, onMouseDo
           ))}
         </StyledCardInfoLeft>
         <StyledCardInfoRight>
-          <TaskInfo title={'스프린트: '} content={taskInfo.sprintId ? sprintList[taskInfo.sprintId].name : ''}></TaskInfo>
+          <TaskInfo
+            title={'스프린트: '}
+            content={taskInfo.sprintId && sprintList[taskInfo.sprintId] ? sprintList[taskInfo.sprintId].name : ''}
+          ></TaskInfo>
           <TaskInfo title={'예상 소요 시간: '} content={taskInfo.estimatedTime ?? ''}>
             {taskInfo.estimatedTime ? (
               <SmallText color={'black'} margin={'0 0 0 3px'}>


### PR DESCRIPTION
## 📑 제목
스프린트, 라벨 태스크 삭제 시 발생하는 버그를 해결한다.

## 📎 관련 이슈
- #146

## ✔️ 셀프 체크리스트
스프린트 삭제 확인
라벨 에러 확인

## 💬 작업 내용
스프린트 리스트에 없을 시 제외 처리
라벨 리스트에 없을 시 제외처리
드롭다운에서 스프린트 id number로 처리해서 보내게 수정
![녹화_2021_11_22_21_47_55_765](https://user-images.githubusercontent.com/73219421/142865705-25bb28dc-171b-4a03-bc3f-80deb39a78fb.gif)

## 🚧 PR 특이 사항

서버 쪽에서 정규화를 다시하려 했으나,
joinColumn()을 써도 여전히 쿼리에 fk가 안 담기는 이슈가 있었음
또한 n대n 테이블로 새로 만들려 해도, 테이블이 라벨,태스크 n대n 관계에,  1대n 프로젝트 관계로 이루어지는 애매한 상황에 놓였음.
따라서, noSql 에서 어떻게 처리하는 조사해보던 중,
https://dba.stackexchange.com/questions/98249/how-do-relations-work-in-nosql 글을 읽고, 어플리케이션에서 제외처리 해줘야겠다고 생각함.
리스트에 없을시 제외처리 해주는 것으로 몇군데를 수정해 해결할 수 있었음.
스프린트는 리로드되거나, 다른 스프린트를 할당하면 삭제되고, 라벨은 데이터가 남아있으나, string 한 두 글자 남아있는 것이, 복잡한 쿼리보다 낫다는  판단.

## 🕰 실제 소요 시간
4h