### PR TITLE
mindmap과 history에 Delete시 SideEffect 반영 

### DIFF
--- a/client/src/components/atoms/Node/index.tsx
+++ b/client/src/components/atoms/Node/index.tsx
@@ -26,7 +26,7 @@ const Node = styled.div<INodeProps>`
   line-height: ${({ theme, level }) => theme.nodeFontSizes[levelToIdx(level)]};
   padding: 0.5rem 1rem;
   cursor: move;
-  border: ${({ isSelected }) => (isSelected ? '2px solid blue' : '2px solid transparent')};
+  border: ${({ theme, isSelected }) => (isSelected ? `2px solid ${theme.color.primary2}` : '2px solid transparent')};
   ${({ status }) => (status ? styledStatus[status] : '')};
   ${({ isFiltered }) => !isFiltered && 'filter: brightness(0.7)'};
 `;

--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -165,15 +165,17 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId
             ref={nodeRef}
             id={nodeId.toString()}
             level={level}
-            isSelected={isSelected || isHistorySelected}
+            isSelected={(!isHistoryOpen && isSelected) || isHistorySelected}
             isFiltered={isFiltered}
             className='node mindmap-area'
             status={status}
           >
             {!!assignee && <UserIcon user={assignee} />}
             {!!priority && <PriorityIcon priority={priority} />}
+            {!isHistoryOpen && !isRoot && isSelected && (
+              <NodeDeleteBtn onClick={handleDeleteBtnClick.bind(null, parentId!, node)}>삭제</NodeDeleteBtn>
+            )}
             {content}
-            {!isRoot && isSelected && <NodeDeleteBtn onClick={handleDeleteBtnClick.bind(null, parentId!, node)}>삭제</NodeDeleteBtn>}
           </Node>
         </>
       )}

--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -6,20 +6,17 @@ import { ITaskFilters } from 'components/organisms/MindmapTree';
 import { NodeContainer, ChildContainer, NodeDeleteBtn } from './style';
 import { getNextMapState, mindmapState, TEMP_NODE_ID } from 'recoil/mindmap';
 import { selectedNodeIdState } from 'recoil/node';
-import { currentHistoryNodeIdState } from 'recoil/history';
+import { currentHistoryNodeIdState, isHistoryOpenState } from 'recoil/history';
 import useHistoryEmitter from 'hooks/useHistoryEmitter';
 import { TCoord, TRect, getCurrentCoord, getGap, getType, calcRect, Levels } from 'utils/helpers';
 import { IMindmapData, IMindNode, IMindNodes } from 'types/mindmap';
-import { IUser } from 'types/user';
+import { assigneeFilterState, labelFilterState, sprintFilterState, userListState } from 'recoil/project';
 
 interface ITreeProps {
   nodeId: number;
   mindmapData: IMindmapData;
   parentCoord: TCoord | null;
   parentId?: number;
-  taskFilters: ITaskFilters;
-  isFiltering: boolean;
-  userList: Record<string, IUser>;
   handleDeleteBtnClick: (parentId: number, node: IMindNode) => void;
 }
 
@@ -65,24 +62,15 @@ const getStatus = ({ isRoot, level, mindNodes, node }: IGetStatusProps) => {
   if (level === 'STORY' && children.length) return isAllTaskDone(node, mindNodes) ? 'Done' : 'To Do';
 };
 
-const Tree: React.FC<ITreeProps> = ({
-  nodeId,
-  mindmapData,
-  parentCoord,
-  parentId,
-  taskFilters,
-  isFiltering,
-  userList,
-  handleDeleteBtnClick,
-}) => {
-  const { rootId, mindNodes } = mindmapData;
-  const node = mindNodes.get(nodeId)!;
-  const { level, content, children, assigneeId, priority } = node;
-  const assignee = assigneeId ? userList[assigneeId] : null;
-  const isRoot = nodeId === rootId;
-  const isFiltered = isFiltering ? isFilteredTask({ level, node, taskFilters }) : true;
-
-  const status = getStatus({ mindNodes, node, level, isRoot });
+const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId, handleDeleteBtnClick }) => {
+  const taskFilters: ITaskFilters = {
+    sprint: useRecoilValue(sprintFilterState),
+    user: useRecoilValue(assigneeFilterState),
+    label: useRecoilValue(labelFilterState),
+  };
+  const userList = useRecoilValue(userListState);
+  const isHistoryOpen = useRecoilValue(isHistoryOpenState);
+  const isFiltering = !!Object.values(taskFilters).reduce((acc, filter) => (acc += filter ? filter : ''), '');
 
   const { addNode } = useHistoryEmitter();
   const setMindmapData = useSetRecoilState(mindmapState);
@@ -97,6 +85,15 @@ const Tree: React.FC<ITreeProps> = ({
   const [rect, setRect] = useState<TRect | null>(null);
   const nodeRef = useRef<HTMLDivElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const { rootId, mindNodes } = mindmapData;
+  const node = mindNodes.get(nodeId)!;
+  const { level, content, children, assigneeId, priority } = node;
+  const assignee = assigneeId ? userList[assigneeId] : null;
+  const isRoot = nodeId === rootId;
+  const isFiltered = isFiltering ? isFilteredTask({ level, node, taskFilters }) : true;
+
+  const status = getStatus({ mindNodes, node, level, isRoot });
 
   useEffect(() => {
     if (!nodeRef.current || !containerRef.current) return;
@@ -188,9 +185,6 @@ const Tree: React.FC<ITreeProps> = ({
             mindmapData={mindmapData}
             parentCoord={coord}
             parentId={nodeId}
-            taskFilters={taskFilters}
-            isFiltering={isFiltering}
-            userList={userList}
             handleDeleteBtnClick={handleDeleteBtnClick}
           />
         ))}

--- a/client/src/components/molecules/Tree/style.tsx
+++ b/client/src/components/molecules/Tree/style.tsx
@@ -18,9 +18,9 @@ export const ChildContainer = styled.div`
 `;
 
 export const NodeDeleteBtn = styled.div`
-  color: ${(props) => props.theme.color.white};
-  background: blue;
-  font-size: ${(props) => props.theme.fontSize.small};
+  color: ${({ theme }) => theme.color.white};
+  background: ${({ theme }) => theme.color.primary2};
+  font-size: ${({ theme }) => theme.fontSize.small};
   border-radius: 1rem;
   padding: 0.2rem;
   position: absolute;

--- a/client/src/components/organisms/MindmapTree/index.tsx
+++ b/client/src/components/organisms/MindmapTree/index.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useRecoilValue } from 'recoil';
 import { assigneeFilterState, labelFilterState, sprintFilterState, userListState } from 'recoil/project';
 import { IMindmapData, IMindNode } from 'types/mindmap';
+import { getAllChildren } from 'utils/helpers';
 
 interface IProps {
   mindmapData: IMindmapData;
@@ -27,7 +28,8 @@ const MindmapTree: React.FC<IProps> = ({ mindmapData }) => {
   const isFiltering = !!Object.values(taskFilters).reduce((acc, filter) => (acc += filter ? filter : ''), '');
 
   const handleDeleteBtnClick = (parentId: number, node: IMindNode) => {
-    deleteNode({ nodeFrom: parentId, dataFrom: node });
+    const sideEffect: IMindNode[] = getAllChildren(node, mindmapData);
+    deleteNode({ nodeFrom: parentId, dataFrom: { ...node, sideEffect: sideEffect } });
   };
 
   return (

--- a/client/src/components/organisms/MindmapTree/index.tsx
+++ b/client/src/components/organisms/MindmapTree/index.tsx
@@ -1,8 +1,6 @@
 import { Tree } from 'components/molecules';
 import useHistoryEmitter from 'hooks/useHistoryEmitter';
 import React from 'react';
-import { useRecoilValue } from 'recoil';
-import { assigneeFilterState, labelFilterState, sprintFilterState, userListState } from 'recoil/project';
 import { IMindmapData, IMindNode } from 'types/mindmap';
 import { getAllChildren } from 'utils/helpers';
 
@@ -18,32 +16,14 @@ export interface ITaskFilters {
 
 const MindmapTree: React.FC<IProps> = ({ mindmapData }) => {
   const rootId = mindmapData.rootId;
-  const userList = useRecoilValue(userListState);
   const { deleteNode } = useHistoryEmitter();
-  const taskFilters: ITaskFilters = {
-    sprint: useRecoilValue(sprintFilterState),
-    user: useRecoilValue(assigneeFilterState),
-    label: useRecoilValue(labelFilterState),
-  };
-  const isFiltering = !!Object.values(taskFilters).reduce((acc, filter) => (acc += filter ? filter : ''), '');
 
   const handleDeleteBtnClick = (parentId: number, node: IMindNode) => {
     const sideEffect: IMindNode[] = getAllChildren(node, mindmapData);
     deleteNode({ nodeFrom: parentId, dataFrom: { ...node, sideEffect: sideEffect } });
   };
 
-  return (
-    <Tree
-      key={rootId}
-      nodeId={rootId}
-      mindmapData={mindmapData}
-      parentCoord={null}
-      taskFilters={taskFilters}
-      isFiltering={isFiltering}
-      userList={userList}
-      handleDeleteBtnClick={handleDeleteBtnClick}
-    />
-  );
+  return <Tree key={rootId} nodeId={rootId} mindmapData={mindmapData} parentCoord={null} handleDeleteBtnClick={handleDeleteBtnClick} />;
 };
 
 export default MindmapTree;

--- a/client/src/hooks/useHistoryEmitter/index.ts
+++ b/client/src/hooks/useHistoryEmitter/index.ts
@@ -53,14 +53,8 @@ const useHistoryEmitter = () => {
   const deleteNode = ({ nodeFrom, dataFrom }: THistoryEventData) =>
     historyEmitter({ type: 'DELETE_NODE', payload: { nodeFrom, dataFrom } });
 
-  const moveNode = ({ nodeFrom, nodeTo, dataFrom, dataTo }: THistoryEventData) =>
-    historyEmitter({ type: 'MOVE_NODE', payload: { nodeFrom, nodeTo, dataFrom, dataTo } });
-
   const updateNodeParent = ({ nodeFrom, nodeTo, dataFrom, dataTo }: THistoryEventData) =>
     historyEmitter({ type: 'UPDATE_NODE_PARENT', payload: { nodeFrom, nodeTo, dataFrom, dataTo } });
-
-  const updateNodeSibling = ({ nodeFrom, nodeTo, dataFrom, dataTo }: THistoryEventData) =>
-    historyEmitter({ type: 'UPDATE_NODE_SIBLING', payload: { nodeFrom, nodeTo, dataFrom, dataTo } });
 
   const updateNodeContent = ({ nodeFrom, dataFrom, dataTo }: THistoryEventData) =>
     historyEmitter({ type: 'UPDATE_NODE_CONTENT', payload: { nodeFrom, dataFrom, dataTo } });
@@ -78,9 +72,7 @@ const useHistoryEmitter = () => {
   return {
     addNode,
     deleteNode,
-    moveNode,
     updateNodeParent,
-    updateNodeSibling,
     updateNodeContent,
     updateTaskInformation,
     addLabel,

--- a/client/src/hooks/useHistoryReceiver/index.ts
+++ b/client/src/hooks/useHistoryReceiver/index.ts
@@ -5,6 +5,7 @@ import {
   INonHistoryEventData,
   TAddNodeData,
   TDeleteLabel,
+  TDeleteNodeData,
   TDeleteSprint,
   THistoryEventData,
   TTask,
@@ -14,7 +15,7 @@ import {
 } from 'types/event';
 import { IHistoryData } from 'types/history';
 import { ILabel } from 'types/label';
-import { IMindmapData, IMindNode, IMindNodes } from 'types/mindmap';
+import { IMindmapData, IMindNodes } from 'types/mindmap';
 import { ISprint } from 'types/sprint';
 import { getChildLevel, levelToIdx, setTreeLevel } from 'utils/helpers';
 
@@ -82,13 +83,13 @@ export const historyHandler = ({ setMindmap, historyData }: IHistoryHandlerProps
       setMindmap((prev) => {
         const nextMapState = getNextMapState(prev);
         const parentNode = nextMapState.mindNodes.get(nodeFrom!)!;
-        const { nodeId } = dataFrom as IMindNode;
+        const { nodeId, sideEffect } = dataFrom as TDeleteNodeData;
         parentNode.children = parentNode.children.filter((childId) => childId !== nodeId);
         nextMapState.mindNodes.delete(nodeId!);
+        console.log(123123, sideEffect);
+        sideEffect.forEach((childNode) => nextMapState.mindNodes.delete(childNode.nodeId));
         return nextMapState;
       });
-      break;
-    case 'MOVE_NODE':
       break;
     case 'UPDATE_NODE_PARENT':
       setMindmap((prev) => {
@@ -97,8 +98,6 @@ export const historyHandler = ({ setMindmap, historyData }: IHistoryHandlerProps
         updateNodeParent({ nextMapState, oldParentId: nodeFrom!, newParentId: nodeTo!, data });
         return nextMapState;
       });
-      break;
-    case 'UPDATE_NODE_SIBLING':
       break;
     case 'UPDATE_NODE_CONTENT':
       setMindmap((prev) => {

--- a/client/src/hooks/useLog/index.tsx
+++ b/client/src/hooks/useLog/index.tsx
@@ -31,9 +31,7 @@ export const useLog = () => {
   const convertToDescription: TConvertToDescription = {
     ADD_NODE: ({ dataTo }) => `${(dataTo as TAddNodeData).content} 노드가 생성되었습니다.`,
     DELETE_NODE: ({ dataFrom }) => `${(dataFrom as TDeleteNodeData).content} 노드가 삭제되었습니다.`,
-    MOVE_NODE: ({}) => `노드 위치가 변경되었습니다.`,
     UPDATE_NODE_PARENT: () => `노드 레벨이 변경되었습니다.`,
-    UPDATE_NODE_SIBLING: () => `노드 순서가 변경되었습니다.`,
     UPDATE_NODE_CONTENT: ({ dataFrom, dataTo }) =>
       `노드 내용이 '${(dataFrom as TUpdateNodeContent).content}'에서 '${(dataTo as TUpdateNodeContent)!.content}'로 변경되었습니다.`,
     UPDATE_TASK_INFORMATION: (data) => {

--- a/client/src/recoil/history/index.ts
+++ b/client/src/recoil/history/index.ts
@@ -49,3 +49,11 @@ export const isHistoryCalculatingState = atom<boolean>({
   key: 'isHistoryIsCalculatingAtom',
   default: false,
 });
+
+export const isHistoryOpenState = selector({
+  key: 'historyOpenState',
+  get: ({ get }) => {
+    const isOpen = !!get(historyDataListState).length;
+    return isOpen;
+  },
+});

--- a/client/src/recoil/history/index.ts
+++ b/client/src/recoil/history/index.ts
@@ -28,12 +28,8 @@ export const currentHistoryNodeIdState = selector({
         return (currentNodeData.data.dataTo! as TAddNodeData).nodeId;
       case 'DELETE_NODE':
         return (currentNodeData.data.dataFrom! as TDeleteNodeData).nodeId;
-      case 'MOVE_NODE':
-        return currentNodeData.data.nodeFrom! as THistoryEventData;
       case 'UPDATE_NODE_PARENT':
         return (currentNodeData.data.dataFrom! as TUpdateNodeParent).nodeId;
-      case 'UPDATE_NODE_SIBLING':
-        return currentNodeData.data.nodeFrom! as THistoryEventData;
       case 'UPDATE_NODE_CONTENT':
         return currentNodeData.data.nodeFrom! as THistoryEventData;
       case 'UPDATE_TASK_INFORMATION':

--- a/client/src/types/event.ts
+++ b/client/src/types/event.ts
@@ -9,7 +9,9 @@ export type TAddNodeData = {
 };
 export type TPriority = '낮음' | '보통' | '높음';
 export type TStatus = 'To Do' | 'In Progress' | 'Done';
-export type TDeleteNodeData = IMindNode;
+export interface TDeleteNodeData extends IMindNode {
+  sideEffect: Array<IMindNode>;
+}
 export type TMoveNodeData = {
   posX?: string;
   posY?: string;

--- a/client/src/types/event.ts
+++ b/client/src/types/event.ts
@@ -1,4 +1,3 @@
-import { Levels } from 'utils/helpers';
 import { ILabel } from './label';
 import { IMindNode } from './mindmap';
 import { ISprint } from './sprint';
@@ -12,18 +11,10 @@ export type TStatus = 'To Do' | 'In Progress' | 'Done';
 export interface TDeleteNodeData extends IMindNode {
   sideEffect: Array<IMindNode>;
 }
-export type TMoveNodeData = {
-  posX?: string;
-  posY?: string;
-};
 export type TUpdateNodeParent = {
   nodeId: number;
   nodeType: 'EPIC' | 'STORY' | 'TASK';
   nodeParentType: 'ROOT' | 'EPIC' | 'STORY';
-};
-export type TUpdateNodeSibling = {
-  parentId: number;
-  children: number[];
 };
 export type TUpdateNodeContent = {
   content: string;
@@ -67,19 +58,12 @@ export type TDeleteComment = {
   commentId: number;
 };
 
-export type THistoryEventType =
-  | 'ADD_NODE'
-  | 'DELETE_NODE'
-  | 'MOVE_NODE'
-  | 'UPDATE_NODE_PARENT'
-  | 'UPDATE_NODE_SIBLING'
-  | 'UPDATE_NODE_CONTENT'
-  | 'UPDATE_TASK_INFORMATION';
+export type THistoryEventType = 'ADD_NODE' | 'DELETE_NODE' | 'UPDATE_NODE_PARENT' | 'UPDATE_NODE_CONTENT' | 'UPDATE_TASK_INFORMATION';
 export type THistoryEventData = {
   nodeFrom?: number | null;
   nodeTo?: number | null;
-  dataFrom?: TDeleteNodeData | TMoveNodeData | TUpdateNodeParent | TUpdateNodeSibling | TUpdateNodeContent | TUpdateTaskInformation | null;
-  dataTo?: TAddNodeData | TMoveNodeData | TUpdateNodeParent | TUpdateNodeSibling | TUpdateNodeContent | TUpdateTaskInformation | null;
+  dataFrom?: TDeleteNodeData | TUpdateNodeParent | TUpdateNodeContent | TUpdateTaskInformation | null;
+  dataTo?: TAddNodeData | TUpdateNodeParent | TUpdateNodeContent | TUpdateTaskInformation | null;
 };
 
 export type TEventType = 'ADD_SPRINT' | 'ADD_LABEL' | 'ADD_COMMENT' | 'DELETE_SPRINT' | 'DELETE_LABEL' | 'DELETE_COMMENT';

--- a/client/src/types/mindmap.ts
+++ b/client/src/types/mindmap.ts
@@ -15,7 +15,4 @@ export interface IMindNode extends TTask {
   children: Array<number>;
   backlogId?: string;
   createdAt?: string;
-  comment?: [];
-  posX?: string;
-  posY?: string;
 }

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -1,5 +1,5 @@
 import { THistoryEventData } from 'types/event';
-import { IMindNodes } from 'types/mindmap';
+import { IMindmapData, IMindNode, IMindNodes } from 'types/mindmap';
 
 interface ICoord {
   x: number;
@@ -115,6 +115,19 @@ const setTreeLevel = (mindNodes: IMindNodes, nodeId: number, depth: number) => {
   node.children.forEach((childId) => setTreeLevel(mindNodes, childId, depth + 1));
 };
 
+const getAllChildren = (node: IMindNode, mindmapData: IMindmapData) => {
+  const allChildren: Array<IMindNode> = [];
+  node.children.forEach((childId) => {
+    const childNode = mindmapData.mindNodes.get(childId)!;
+    allChildren.push(childNode);
+    childNode?.children.forEach((grandChildId) => {
+      const grandChildNode = mindmapData.mindNodes.get(grandChildId)!;
+      allChildren.push(grandChildNode);
+    });
+  });
+  return allChildren;
+};
+
 export {
   getChildLevel,
   fillPayload,
@@ -132,6 +145,7 @@ export {
   idxToLevel,
   levelToIdx,
   setTreeLevel,
+  getAllChildren,
 };
 export type TRect = IRect;
 export type TCoord = ICoord;

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -2,7 +2,7 @@ import { SetterOrUpdater } from 'recoil';
 import { getNextMapState } from 'recoil/mindmap';
 import { IMindmapData, IMindNode, IMindNodes } from 'types/mindmap';
 import { IHistoryData } from 'types/history';
-import { TAddNodeData, TDeleteNodeData, TMoveNodeData, TUpdateNodeParent, TUpdateNodeSibling, TUpdateTaskInformation } from 'types/event';
+import { TAddNodeData, TDeleteNodeData, TUpdateNodeParent, TUpdateTaskInformation } from 'types/event';
 
 interface IParams {
   historyData: IHistoryData;
@@ -27,10 +27,6 @@ export const restoreHistory = (params: IParams) => {
       if (isForward) deleteNode({ historyData, historyMap });
       else addNode({ historyMap, parentId: nodeFrom!, dataFrom: dataFrom as TDeleteNodeData, dataTo: dataTo as IMindNode });
       break;
-    case 'MOVE_NODE':
-      if (isForward) moveNode({ data: historyData.data.dataTo as TMoveNodeData, id: historyData.data.nodeFrom!, historyMap });
-      else moveNode({ data: historyData.data.dataFrom as TMoveNodeData, id: historyData.data.nodeFrom!, historyMap });
-      break;
     case 'UPDATE_NODE_CONTENT':
       updateNodeContent({
         historyData,
@@ -53,10 +49,6 @@ export const restoreHistory = (params: IParams) => {
           data: historyData.data.dataFrom as TUpdateNodeParent,
           historyMap,
         });
-      break;
-    case 'UPDATE_NODE_SIBLING':
-      if (isForward) updateNodeSibling({ data: historyData.data.dataTo as TUpdateNodeSibling, historyMap });
-      else updateNodeSibling({ data: historyData.data.dataFrom as TUpdateNodeSibling, historyMap });
       break;
     case 'UPDATE_TASK_INFORMATION':
       if (isForward)
@@ -107,20 +99,6 @@ const updateNodeContent = ({ historyData, historyMap, isForward }: IUpdateNodeCo
   historyMap.set(id!, { ...node, ...(isForward ? dataTo : dataFrom) });
 };
 
-interface IMoveNodeParams {
-  data: TMoveNodeData;
-  id: number;
-  historyMap: IMindNodes;
-}
-
-const moveNode = ({ data, id, historyMap }: IMoveNodeParams) => {
-  const node = historyMap.get(id);
-  node!.posX = data.posX;
-  node!.posY = data.posY;
-
-  historyMap.set(id, node!);
-};
-
 interface IDeleteNodeParams {
   historyData: IHistoryData;
   historyMap: IMindNodes;
@@ -168,19 +146,6 @@ const updateNodeParent = ({ from, to, data, historyMap }: IUpdateNodeParentParam
 
   historyMap.set(from, fromNode);
   historyMap.set(to, toNode);
-};
-
-interface IUpdateNodeSiblingParams {
-  data: TUpdateNodeSibling;
-  historyMap: IMindNodes;
-}
-
-const updateNodeSibling = ({ data, historyMap }: IUpdateNodeSiblingParams) => {
-  const { parentId, children } = data;
-  const parent = historyMap.get(parentId)!;
-
-  parent.children = children;
-  historyMap.set(parentId, parent);
 };
 
 interface IUpdateNodeInformationParams {

--- a/client/src/utils/historyHandler.ts
+++ b/client/src/utils/historyHandler.ts
@@ -20,12 +20,12 @@ export const restoreHistory = (params: IParams) => {
 
   switch (historyData.type) {
     case 'ADD_NODE':
-      if (isForward) addNode({ historyMap, parentId: nodeFrom!, dataFrom: dataFrom as IMindNode, dataTo: dataTo as IMindNode });
+      if (isForward) addNode({ historyMap, parentId: nodeFrom!, dataFrom: dataFrom as TDeleteNodeData, dataTo: dataTo as IMindNode });
       else deleteNode({ historyData, historyMap, setHistoryDataList, historyDataList });
       break;
     case 'DELETE_NODE':
       if (isForward) deleteNode({ historyData, historyMap });
-      else addNode({ historyMap, parentId: nodeFrom!, dataFrom: dataFrom as IMindNode, dataTo: dataTo as IMindNode });
+      else addNode({ historyMap, parentId: nodeFrom!, dataFrom: dataFrom as TDeleteNodeData, dataTo: dataTo as IMindNode });
       break;
     case 'MOVE_NODE':
       if (isForward) moveNode({ data: historyData.data.dataTo as TMoveNodeData, id: historyData.data.nodeFrom!, historyMap });
@@ -37,7 +37,6 @@ export const restoreHistory = (params: IParams) => {
         historyMap,
         isForward,
       });
-
       break;
     case 'UPDATE_NODE_PARENT':
       if (isForward)
@@ -87,6 +86,12 @@ const addNode = ({ historyMap, parentId, dataTo, dataFrom }: IAddNodeParams) => 
 
   historyMap.set(parentId, { ...parent!, children: [...parent.children, nodeId!] });
   historyMap.set(nodeId!, newNode as IMindNode);
+
+  if (dataTo) return;
+
+  dataFrom.sideEffect.forEach((node) => {
+    historyMap.set(node.nodeId, node);
+  });
 };
 
 interface IUpdateNodeContentParams {
@@ -134,7 +139,7 @@ const deleteNode = ({ historyData, historyMap, setHistoryDataList }: IDeleteNode
   const newChildren = historyData.data.dataFrom ? parent.children.filter((cid) => cid !== childId) : parent.children.slice(0, -1);
   historyMap.set(parentId, { ...parent, children: newChildren });
 
-  if (historyData.data.dataTo && !(historyData.data.dataTo! as TAddNodeData).nodeId) {
+  if (historyData.data.dataTo && !(historyData.data.dataTo as TAddNodeData).nodeId) {
     const newDataTo = { ...historyData.data.dataTo, nodeId: childId };
     const newHistory = { ...historyData!, data: { ...historyData.data, dataTo: newDataTo } };
 

--- a/server/src/database/entities/Mindmap.ts
+++ b/server/src/database/entities/Mindmap.ts
@@ -16,12 +16,6 @@ export class Mindmap {
   @Column()
   content: string;
 
-  @Column({ default: null })
-  posX: string;
-
-  @Column({ default: null })
-  posY: string;
-
   @CreateDateColumn()
   createdAt: Date;
 

--- a/server/src/services/mindmap.ts
+++ b/server/src/services/mindmap.ts
@@ -6,8 +6,6 @@ interface INode {
   level?: string;
   label?: string;
   content?: string;
-  posX?: string;
-  posY?: string;
   children?: string;
 }
 

--- a/server/src/services/project.ts
+++ b/server/src/services/project.ts
@@ -47,8 +47,6 @@ export const createProject = async (name: string, creator: string) => {
   const rootId = await createNode(newProject.id, null, {
     level: 'ROOT',
     content: name,
-    posX: '0',
-    posY: '0',
     children: JSON.stringify([]),
   });
   newProject.rootId = rootId;

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -23,20 +23,11 @@ const historyEventFunction = (): Record<eventType.THistoryEventType, THistoryEve
       deleteNode(nodeFrom, (dataFrom as eventType.TDeleteNodeData).nodeId);
       return;
     },
-    MOVE_NODE: ({ nodeTo, dataTo }) => {
-      updateNode(nodeTo, dataTo as eventType.TMoveNodeData);
-      return;
-    },
     UPDATE_NODE_PARENT: ({ nodeFrom, nodeTo, dataTo }) => {
       const { nodeId, nodeType, nodeParentType } = dataTo as eventType.TUpdateNodeParent;
       updateNodeParent(nodeFrom, nodeTo, nodeId);
       if (nodeType === 'TASK' && nodeParentType !== 'STORY') deleteTask(nodeId);
       if (nodeType === 'STORY' && nodeParentType !== 'EPIC') deleteChildTasks(nodeId);
-      return;
-    },
-    UPDATE_NODE_SIBLING: ({ dataTo }) => {
-      const { parentId, children } = dataTo as eventType.TUpdateNodeSibling;
-      updateNode(parentId, { children: JSON.stringify(children) });
       return;
     },
     UPDATE_NODE_CONTENT: ({ nodeFrom, dataTo }) => {

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -9,23 +9,12 @@ export interface TDeleteNodeData extends TTask {
   children: Array<number>;
   backlogId?: string;
   createdAt?: string;
-  comment?: [];
-  posX?: string;
-  posY?: string;
   sideEffect: [];
 }
-export type TMoveNodeData = {
-  posX?: string;
-  posY?: string;
-};
 export type TUpdateNodeParent = {
   nodeId: number;
   nodeType: 'EPIC' | 'STORY' | 'TASK';
   nodeParentType: 'ROOT' | 'EPIC' | 'STORY';
-};
-export type TUpdateNodeSibling = {
-  parentId: number;
-  children: number[];
 };
 export type TUpdateNodeContent = {
   content: string;
@@ -61,19 +50,12 @@ export type TDeleteLabel = {
   labelId: number;
 };
 
-export type THistoryEventType =
-  | 'ADD_NODE'
-  | 'DELETE_NODE'
-  | 'MOVE_NODE'
-  | 'UPDATE_NODE_PARENT'
-  | 'UPDATE_NODE_SIBLING'
-  | 'UPDATE_NODE_CONTENT'
-  | 'UPDATE_TASK_INFORMATION';
+export type THistoryEventType = 'ADD_NODE' | 'DELETE_NODE' | 'UPDATE_NODE_PARENT' | 'UPDATE_NODE_CONTENT' | 'UPDATE_TASK_INFORMATION';
 export type THistoryEventData = {
   nodeFrom: number | null;
   nodeTo: number | null;
-  dataFrom: TDeleteNodeData | TMoveNodeData | TUpdateNodeParent | TUpdateNodeSibling | TUpdateNodeContent | TUpdateTaskInformation | null;
-  dataTo: TAddNodeData | TMoveNodeData | TUpdateNodeParent | TUpdateNodeSibling | TUpdateNodeContent | TUpdateTaskInformation | null;
+  dataFrom: TDeleteNodeData | TUpdateNodeParent | TUpdateNodeContent | TUpdateTaskInformation | null;
+  dataTo: TAddNodeData | TUpdateNodeParent | TUpdateNodeContent | TUpdateTaskInformation | null;
 };
 
 export type TEventType = 'ADD_SPRINT' | 'ADD_LABEL' | 'DELETE_SPRINT' | 'DELETE_LABEL';

--- a/server/src/utils/event-type.ts
+++ b/server/src/utils/event-type.ts
@@ -12,6 +12,7 @@ export interface TDeleteNodeData extends TTask {
   comment?: [];
   posX?: string;
   posY?: string;
+  sideEffect: [];
 }
 export type TMoveNodeData = {
   posX?: string;


### PR DESCRIPTION
## 📑 제목
mindmap과 history에 Delete시 SideEffect 반영 

## 📎 관련 이슈
- #142

## ✔️ 셀프 체크리스트
- [X] 히스토리바에서 노드 삭제 관련 기능이 정상 동작 하는가

## 💬 작업 내용
- mindmap과 history에 Delete시 SideEffect 반영  
- 노드 focus 색상 primary2로 변경  
- move_node, update_sibling 관련 코드 제거  
- historybar 열릴 시 유저 focus 지워지도록 변경 

## 🚧 PR 특이 사항
- 잘 동작하는 듯 보입니다

## 🕰 실제 소요 시간

1.5hr