### PR TITLE
번다운차트, 파이차트

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,15 @@
 {
-  "cSpell.words": ["Mindmap", "typeorm", "xadd", "xread", "xrevrange", "middleware", "middlewares"]
+  "cSpell.words": [
+    "Burndown",
+    "drilldown",
+    "highcharts",
+    "middleware",
+    "middlewares",
+    "Mindmap",
+    "typeorm",
+    "xadd",
+    "xread",
+    "xrevrange",
+    "xxxlarge"
+  ]
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -21,6 +21,8 @@
         "@types/react-router-dom": "^5.3.2",
         "axios": "^0.24.0",
         "emotion-reset": "^3.0.1",
+        "highcharts": "^9.3.1",
+        "highcharts-react-official": "^3.1.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.3.0",
@@ -11017,6 +11019,20 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "node_modules/highcharts": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.1.tgz",
+      "integrity": "sha512-T5BjvY2CDtqlKRbid1Jd22psBp8tV9+7fm+x7h+EZuXF0OVDLR5128sRuC6WCWVss4cTVzS6PKnlnXKfYskIhw=="
+    },
+    "node_modules/highcharts-react-official": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.1.0.tgz",
+      "integrity": "sha512-CkWJHrVMOc6CT8KFu1dR+a0w5OxCVKKgZUNWtEi5TmR0xqBDIDe+RyM652MAN/jBYppxMo6TCUVlRObCyWAn0Q==",
+      "peerDependencies": {
+        "highcharts": ">=6.0.0",
+        "react": ">=16.8.0"
+      }
     },
     "node_modules/history": {
       "version": "4.10.1",
@@ -32764,6 +32780,17 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
+    },
+    "highcharts": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-9.3.1.tgz",
+      "integrity": "sha512-T5BjvY2CDtqlKRbid1Jd22psBp8tV9+7fm+x7h+EZuXF0OVDLR5128sRuC6WCWVss4cTVzS6PKnlnXKfYskIhw=="
+    },
+    "highcharts-react-official": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/highcharts-react-official/-/highcharts-react-official-3.1.0.tgz",
+      "integrity": "sha512-CkWJHrVMOc6CT8KFu1dR+a0w5OxCVKKgZUNWtEi5TmR0xqBDIDe+RyM652MAN/jBYppxMo6TCUVlRObCyWAn0Q==",
+      "requires": {}
     },
     "history": {
       "version": "4.10.1",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,8 @@
     "@types/react-router-dom": "^5.3.2",
     "axios": "^0.24.0",
     "emotion-reset": "^3.0.1",
+    "highcharts": "^9.3.1",
+    "highcharts-react-official": "^3.1.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.0",

--- a/client/src/components/atoms/Title/index.tsx
+++ b/client/src/components/atoms/Title/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyledTitle, TColor, TStyle } from './style';
+import { StyledTitle, TColor, TCursor, TStyle } from './style';
 
 interface IProps {
   children?: React.ReactNode;
@@ -7,11 +7,19 @@ interface IProps {
   color?: TColor;
   margin?: string;
   lineHeight?: number;
+  cursor?: TCursor;
 }
 
-const Title: React.FC<IProps> = ({ children, margin = '0.5rem 0', color = 'black', titleStyle = 'normal', lineHeight }) => {
+const Title: React.FC<IProps> = ({
+  children,
+  margin = '0.5rem 0',
+  color = 'black',
+  titleStyle = 'normal',
+  lineHeight,
+  cursor = 'default',
+}) => {
   return (
-    <StyledTitle titleStyle={titleStyle} color={color} margin={margin} lineHeight={lineHeight}>
+    <StyledTitle titleStyle={titleStyle} color={color} margin={margin} lineHeight={lineHeight} cursor={cursor}>
       {children}
     </StyledTitle>
   );

--- a/client/src/components/atoms/Title/style.ts
+++ b/client/src/components/atoms/Title/style.ts
@@ -6,10 +6,12 @@ interface IStyleProps {
   color: TColor;
   margin?: string;
   lineHeight?: number;
+  cursor?: TCursor;
 }
 
 export type TStyle = 'small' | 'normal' | 'large' | 'xlarge' | 'xxxlarge' | 'title';
 export type TColor = 'black' | 'white';
+export type TCursor = 'default' | 'pointer' | 'text' | 'none';
 
 export const StyledTitle = styled.div<IStyleProps>`
   ${({ titleStyle }) => styleOptions[titleStyle]}
@@ -17,7 +19,7 @@ export const StyledTitle = styled.div<IStyleProps>`
   margin: ${({ margin }) => margin};
   font-weight: bold;
   line-height: ${({ lineHeight }) => lineHeight ?? 1.2};
-  cursor: default;
+  cursor: ${({ cursor }) => cursor};
 `;
 
 const styleOptions: { [key in TStyle]: string } = {

--- a/client/src/components/organisms/BurnDownChart/index.tsx
+++ b/client/src/components/organisms/BurnDownChart/index.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import { useRecoilValue } from 'recoil';
+import { sprintBurnDownState } from 'recoil/project';
+
+interface IProps {
+  child?: string;
+}
+
+const BurnDownChart: React.FC<IProps> = () => {
+  const sprintInfoTask = useRecoilValue(sprintBurnDownState);
+  const options = {
+    title: {
+      text: 'Burndown Chart',
+      x: -20,
+    },
+    colors: ['blue', 'red'],
+    plotOptions: {
+      line: {
+        lineWidth: 3,
+      },
+    },
+    xAxis: {
+      categories: sprintInfoTask.map((info) => info.sprintName),
+    },
+    yAxis: {
+      title: {
+        text: 'Hours',
+      },
+      plotLines: [
+        {
+          value: 0,
+          width: 1,
+        },
+      ],
+    },
+    tooltip: {
+      valueSuffix: ' 시간',
+      shared: true,
+    },
+    legend: {
+      layout: 'vertical',
+      align: 'right',
+      verticalAlign: 'middle',
+      borderWidth: 0,
+    },
+    series: [
+      {
+        name: '예상 시간',
+        color: 'rgba(255,0,0,0.25)',
+        lineWidth: 2,
+        data: sprintInfoTask.map((info) => info.totalEstimatedTime),
+      },
+      {
+        name: '실제 시간',
+        color: 'rgba(0,120,200,0.75)',
+        data: sprintInfoTask.map((info) => info.totalFinishedTime),
+      },
+    ],
+  };
+  return <HighchartsReact highcharts={Highcharts} options={options} containerProps={{ style: { height: '100%', width: '100%' } }} />;
+};
+
+export default BurnDownChart;

--- a/client/src/components/organisms/TaskRatioChart/index.tsx
+++ b/client/src/components/organisms/TaskRatioChart/index.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import drilldown from 'highcharts/modules/drilldown';
+import { useRecoilValue } from 'recoil';
+import { userTaskRatioState } from 'recoil/project';
+drilldown(Highcharts);
+const TaskRatioChart: React.FC = () => {
+  const userTaskInfo = useRecoilValue(userTaskRatioState);
+  const totalEstimatedTime = userTaskInfo.reduce((pre, info) => pre + info.totalUserTaskEstimatedTime, 0);
+  const options = {
+    chart: {
+      type: 'pie',
+    },
+    title: {
+      text: '담당한 일 비율',
+    },
+    accessibility: {
+      announceNewData: {
+        enabled: true,
+      },
+      point: {
+        valueSuffix: '%',
+      },
+    },
+
+    plotOptions: {
+      series: {
+        dataLabels: {
+          enabled: true,
+          format: '{point.name}: {point.y:.1f}%',
+        },
+      },
+    },
+
+    tooltip: {
+      enabled: false,
+    },
+
+    series: [
+      {
+        name: '담당자',
+        colorByPoint: true,
+        data: userTaskInfo.map((info) => {
+          return {
+            name: info.userName,
+            y: 100 * (info.totalUserTaskEstimatedTime / totalEstimatedTime),
+            taskTime: info.totalUserTaskEstimatedTime,
+            drilldown: info.userName,
+          };
+        }),
+      },
+    ],
+    drilldown: {
+      series: userTaskInfo.map((info) => {
+        return {
+          name: info.userName,
+          id: info.userName,
+          taskTime: info.totalUserTaskEstimatedTime,
+          data: info.tasks.map((task) => [task[0], 100 * (task[1] / totalEstimatedTime)]),
+        };
+      }),
+    },
+  };
+  return <HighchartsReact highcharts={Highcharts} options={options} containerProps={{ style: { height: '100%', width: '100%' } }} />;
+};
+
+export default TaskRatioChart;

--- a/client/src/components/organisms/index.tsx
+++ b/client/src/components/organisms/index.tsx
@@ -18,3 +18,5 @@ export { default as HistoryBackground } from 'components/organisms/HistoryBackgr
 export { default as TaskCard } from 'components/organisms/TaskCard';
 export { default as HistoryHeader } from 'components/organisms/HistoryHeader';
 export { default as UserInProgressList } from 'components/organisms/UserInProgressList';
+export { default as BurnDownChart } from 'components/organisms/BurnDownChart';
+export { default as TaskRatioChart } from 'components/organisms/TaskRatioChart';

--- a/client/src/components/templates/ChartContainer/ChartHeader.tsx
+++ b/client/src/components/templates/ChartContainer/ChartHeader.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { StyledChartHeader, StyledTitleWrapper, StyledTitleUnderline } from './style';
+import { Title } from 'components/atoms';
+import { useRecoilState } from 'recoil';
+import { selectedChartState } from 'recoil/chart';
+
+const ChartHeader: React.FC = () => {
+  const [selectedChart, setSelectedChart] = useRecoilState(selectedChartState);
+  const handleOnClickChartTitle = (event: React.MouseEvent<HTMLElement>) => {
+    const type = event.currentTarget.dataset.type;
+    if (type) setSelectedChart(type);
+  };
+  return (
+    <StyledChartHeader>
+      <StyledTitleWrapper onClick={handleOnClickChartTitle} data-type={'burndown'}>
+        <Title color={'black'} cursor={'pointer'}>
+          {'번다운 차트'}
+        </Title>
+        {selectedChart === 'burndown' ? <StyledTitleUnderline /> : null}
+      </StyledTitleWrapper>
+      <StyledTitleWrapper onClick={handleOnClickChartTitle} data-type={'velocity'}>
+        <Title color={'black'} cursor={'pointer'}>
+          {'속도'}
+        </Title>
+        {selectedChart === 'velocity' ? <StyledTitleUnderline /> : null}
+      </StyledTitleWrapper>
+      <StyledTitleWrapper onClick={handleOnClickChartTitle} data-type={'task-ratio'}>
+        <Title color={'black'} cursor={'pointer'}>
+          {'담당한 일 비율'}
+        </Title>
+        {selectedChart === 'task-ratio' ? <StyledTitleUnderline /> : null}
+      </StyledTitleWrapper>
+      <StyledTitleWrapper onClick={handleOnClickChartTitle} data-type={'priority'}>
+        <Title color={'black'} cursor={'pointer'}>
+          {'우선 순위 별 완료도'}
+        </Title>
+        {selectedChart === 'priority' ? <StyledTitleUnderline /> : null}
+      </StyledTitleWrapper>
+      <StyledTitleWrapper onClick={handleOnClickChartTitle} data-type={'finished-task'}>
+        <Title color={'black'} cursor={'pointer'}>
+          {'완료한 태스크 수'}
+        </Title>
+        {selectedChart === 'finished-task' ? <StyledTitleUnderline /> : null}
+      </StyledTitleWrapper>
+    </StyledChartHeader>
+  );
+};
+
+export default ChartHeader;

--- a/client/src/components/templates/ChartContainer/index.tsx
+++ b/client/src/components/templates/ChartContainer/index.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { BurnDownChart, TaskRatioChart } from 'components/organisms';
+import { StyledChartBackground, StyledChartContainer } from './style';
+import ChartHeader from './ChartHeader';
+import { useRecoilValue } from 'recoil';
+import { selectedChartState } from 'recoil/chart';
+
+const ChartContainer: React.FC = () => {
+  const selectedChart = useRecoilValue(selectedChartState);
+  return (
+    <StyledChartContainer>
+      <ChartHeader />
+      <StyledChartBackground>
+        {selectedChart === 'burndown' ? <BurnDownChart /> : selectedChart === 'task-ratio' ? <TaskRatioChart /> : null}
+      </StyledChartBackground>
+    </StyledChartContainer>
+  );
+};
+
+export default ChartContainer;

--- a/client/src/components/templates/ChartContainer/style.ts
+++ b/client/src/components/templates/ChartContainer/style.ts
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+
+export const StyledChartContainer = styled.div`
+  ${({ theme }) => theme.flex.columnCenter}
+  justify-content: center;
+  margin: auto;
+  width: 100vw;
+  height: 100vh;
+`;
+
+export const StyledChartBackground = styled.div`
+  width: 80%;
+  min-width: 600px;
+  height: 60%;
+  padding: ${({ theme }) => theme.padding.large};
+  background-color: ${({ theme }) => theme.color.white};
+  border-radius: 8px;
+  -webkit-box-shadow: 1px 4px 11px -1px rgba(0, 0, 0, 0.4);
+  box-shadow: 1px 4px 11px -1px rgba(0, 0, 0, 0.4);
+`;
+
+export const StyledChartHeader = styled.div`
+  ${({ theme }) => theme.flex.center}
+  width: 80%;
+  min-width: 600px;
+  height: 60px;
+  margin-bottom: 30px;
+  background-color: ${({ theme }) => theme.color.white};
+  border-radius: 8px;
+  -webkit-box-shadow: 1px 4px 11px -1px rgba(0, 0, 0, 0.3);
+  box-shadow: 1px 4px 11px -1px rgba(0, 0, 0, 0.3);
+`;
+
+export const StyledTitleWrapper = styled.div`
+  ${({ theme }) => theme.flex.columnCenter}
+  margin: 0 auto;
+`;
+
+export const StyledTitleUnderline = styled.div`
+  width: 100%;
+  height: 1px;
+  border: 1px solid ${({ theme }) => theme.color.black};
+`;

--- a/client/src/components/templates/index.tsx
+++ b/client/src/components/templates/index.tsx
@@ -5,3 +5,4 @@ export { default as MindmapTemplate } from 'components/templates/MindmapTemplate
 export { default as NewProjectModalWrapper } from 'components/templates/NewProjectModalWrapper';
 export { default as ProjectCardContainer } from 'components/templates/ProjectCardContainer';
 export { default as TaskCardContainer } from 'components/templates/TaskCardContainer';
+export { default as ChartContainer } from 'components/templates/ChartContainer';

--- a/client/src/pages/Chart/index.tsx
+++ b/client/src/pages/Chart/index.tsx
@@ -1,5 +1,11 @@
+import { ChartContainer, CommonLayout } from 'components/templates';
+
 const Chart = () => {
-  return <div>차트페이지</div>;
+  return (
+    <CommonLayout>
+      <ChartContainer />
+    </CommonLayout>
+  );
 };
 
 export default Chart;

--- a/client/src/recoil/chart/index.ts
+++ b/client/src/recoil/chart/index.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const selectedChartState = atom<string>({
+  key: 'selectedChart',
+  default: 'burndown',
+});


### PR DESCRIPTION
## 📑 제목
번다운차트, 파이차트
## 📎 관련 이슈
- #161 
- #162
## ✔️ 셀프 체크리스트
- [x] 차트 헤더
- [x] 번다운 차트
- [x] 담당한 일 비율 차트
## 💬 작업 내용
- 차트 페이지
![chart1](https://user-images.githubusercontent.com/60315683/143045125-c012e4d8-0c79-4d2c-983f-c376eda00216.gif)
## 🚧 PR 특이 사항
- 번다운 차트를 스프린트 별 예상/실제 시간 비교가 아니라 남은 태스크 시간으로 바꿔야 할 듯?
- 태스크 설정이 꽤 귀찮아서 태스트를 적당히 해봤다. 다양한 상황에 대해서 봐야 함.
## 🕰 실제 소요 시간
8h