### PR TITLE
캘린더 페이지

### DIFF
--- a/client/src/components/atoms/IconImg/index.tsx
+++ b/client/src/components/atoms/IconImg/index.tsx
@@ -4,19 +4,21 @@ import styled from '@emotion/styled';
 interface IProps {
   imgSrc: string;
   altText: string;
+  size?: { width: string; height: string };
 }
 
 const StyledIconImg = styled.img`
-  padding: ${(props) => props.theme.padding.small};
+  ${({ theme }) => theme.flex.columnCenter}
+  padding: ${({ theme }) => theme.padding.small};
   :hover {
     cursor: pointer;
     border-radius: 99px;
-    background: ${(props) => props.theme.color.gray3};
+    background: ${({ theme }) => theme.color.gray3};
   }
 `;
 
-const IconImg: React.FC<IProps> = ({ imgSrc, altText }) => {
-  return <StyledIconImg src={imgSrc} alt={altText} />;
+const IconImg: React.FC<IProps> = ({ imgSrc, altText, size }) => {
+  return <StyledIconImg src={imgSrc} alt={altText} width={size?.width} height={size?.height} />;
 };
 
 export default IconImg;

--- a/client/src/components/molecules/IconButton/index.tsx
+++ b/client/src/components/molecules/IconButton/index.tsx
@@ -7,12 +7,13 @@ interface IProps {
   altText: string;
   margin?: string;
   zIdx?: string;
+  size?: { width: string; height: string };
 }
 
-const IconButton: React.FC<IProps> = ({ onClick, imgSrc, altText, margin, zIdx }) => {
+const IconButton: React.FC<IProps> = ({ onClick, imgSrc, altText, margin, zIdx, size }) => {
   return (
     <TransparentButton onClick={onClick} margin={margin} zIdx={zIdx}>
-      <IconImg imgSrc={imgSrc} altText={altText} />
+      <IconImg imgSrc={imgSrc} altText={altText} size={size} />
     </TransparentButton>
   );
 };

--- a/client/src/components/organisms/BacklogTable/style.ts
+++ b/client/src/components/organisms/BacklogTable/style.ts
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled';
 
 const TableWrapper = styled.table`
-  position: absolute;
   width: 90vw;
-  margin: 7rem 0 0 5vw;
+  margin: 1.5rem 0;
   border-radius: 0.5rem;
   overflow: hidden;
   ${({ theme }) => theme.shadow};
@@ -11,8 +10,7 @@ const TableWrapper = styled.table`
 
 const BacklogInfo = styled.div`
   ${({ theme }) => theme.flex.row};
-  position: absolute;
-  margin: 4.7rem 0 0 11rem;
+  margin: 4.8rem auto 0 11rem;
   gap: 1rem;
   color: ${({ theme }) => theme.color.primary2};
   font-size: ${({ theme }) => theme.fontSize.xxlarge};

--- a/client/src/components/organisms/ScheduleCalendar/Calendar.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/Calendar.tsx
@@ -22,7 +22,7 @@ const Calendar: React.FC<IProps> = ({ currentDateISO }) => {
       {Array(prevDays)
         .fill(0)
         .map((_, idx) => (
-          <CalendarDay key={idx} />
+          <CalendarDay key={idx} disable={true} />
         ))}
       {Array(days)
         .fill(0)
@@ -34,7 +34,7 @@ const Calendar: React.FC<IProps> = ({ currentDateISO }) => {
       {Array(nextDays)
         .fill(0)
         .map((_, idx) => (
-          <CalendarDay key={idx} />
+          <CalendarDay key={idx} disable={true} />
         ))}
     </>
   );

--- a/client/src/components/organisms/ScheduleCalendar/Calendar.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/Calendar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { getTodayISODate, makeISODate, parseISODate } from 'utils/date';
+import { CalendarHeader, CalendarDay } from './style';
+
+interface IProps {
+  currentDateISO: string;
+}
+
+const Calendar: React.FC<IProps> = ({ currentDateISO }) => {
+  const columns = ['일', '월', '화', '수', '목', '금', '토'];
+  const { year, month } = parseISODate(currentDateISO);
+  const prevDays = new Date(year, month - 1, 1).getDay();
+  const days = new Date(year, month, 0).getDate();
+  const nextDays = 6 - new Date(year, month, 0).getDay();
+  const todayISODate = getTodayISODate();
+
+  return (
+    <>
+      {columns.map((column, idx) => (
+        <CalendarHeader key={idx}>{column}</CalendarHeader>
+      ))}
+      {Array(prevDays)
+        .fill(0)
+        .map((_, idx) => (
+          <CalendarDay key={idx} />
+        ))}
+      {Array(days)
+        .fill(0)
+        .map((_, idx) => (
+          <CalendarDay key={idx} today={makeISODate({ year, month, date: idx + 1 }) === todayISODate}>
+            {idx + 1}
+          </CalendarDay>
+        ))}
+      {Array(nextDays)
+        .fill(0)
+        .map((_, idx) => (
+          <CalendarDay key={idx} />
+        ))}
+    </>
+  );
+};
+
+const CalendarMemo = React.memo(Calendar);
+
+export default CalendarMemo;

--- a/client/src/components/organisms/ScheduleCalendar/Day.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/Day.tsx
@@ -44,6 +44,7 @@ const Day: React.FC<IProps> = ({ dayDate, tasks = [], setHoveredNode = () => {},
             onMouseEnter={() => handleHoverTask(task)}
             onMouseLeave={() => handleLeaveTask()}
             delayed={dueAt && !endedAt && today > dueAt}
+            ended={dueAt && endedAt && true}
             blur={blur}
           >{`#${task.nodeId} ${task.content}`}</DayTask>
         );

--- a/client/src/components/organisms/ScheduleCalendar/Day.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/Day.tsx
@@ -1,0 +1,19 @@
+import { getTodayDate, isSameDate } from 'utils/date';
+import { DayWrapper } from './style';
+
+interface IProps {
+  dayDate?: { year: number; month: number; date: number };
+}
+
+const Day: React.FC<IProps> = ({ dayDate }) => {
+  const todayDate = getTodayDate();
+
+  if (!dayDate) {
+    return <DayWrapper disable={true}></DayWrapper>;
+  }
+
+  const { year, month, date } = dayDate;
+  return <DayWrapper today={isSameDate(dayDate, todayDate)}>{date}</DayWrapper>;
+};
+
+export default Day;

--- a/client/src/components/organisms/ScheduleCalendar/Day.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/Day.tsx
@@ -8,9 +8,10 @@ interface IProps {
   dayDate?: { year: number; month: number; date: number };
   tasks?: IMindNode[];
   setHoveredNode?: React.Dispatch<React.SetStateAction<IMindNode | null>>;
+  blur?: boolean;
 }
 
-const Day: React.FC<IProps> = ({ dayDate, tasks = [], setHoveredNode = () => {} }) => {
+const Day: React.FC<IProps> = ({ dayDate, tasks = [], setHoveredNode = () => {}, blur }) => {
   const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
 
   if (!dayDate) {
@@ -43,6 +44,7 @@ const Day: React.FC<IProps> = ({ dayDate, tasks = [], setHoveredNode = () => {} 
             onMouseEnter={() => handleHoverTask(task)}
             onMouseLeave={() => handleLeaveTask()}
             delayed={dueAt && !endedAt && today > dueAt}
+            blur={blur}
           >{`#${task.nodeId} ${task.content}`}</DayTask>
         );
       })}

--- a/client/src/components/organisms/ScheduleCalendar/Day.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/Day.tsx
@@ -1,19 +1,36 @@
+import { useSetRecoilState } from 'recoil';
+import { selectedNodeIdState } from 'recoil/node';
+import { IMindNode } from 'types/mindmap';
 import { getTodayDate, isSameDate } from 'utils/date';
-import { DayWrapper } from './style';
+import { DayTask, DayWrapper } from './style';
 
 interface IProps {
   dayDate?: { year: number; month: number; date: number };
+  tasks?: IMindNode[];
 }
 
-const Day: React.FC<IProps> = ({ dayDate }) => {
+const Day: React.FC<IProps> = ({ dayDate, tasks = [] }) => {
   const todayDate = getTodayDate();
+  const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
 
   if (!dayDate) {
     return <DayWrapper disable={true}></DayWrapper>;
   }
 
+  const handleClickTask = (e: React.MouseEvent, id: number) => {
+    e.stopPropagation();
+    setSelectedNodeId(id);
+  };
+
   const { year, month, date } = dayDate;
-  return <DayWrapper today={isSameDate(dayDate, todayDate)}>{date}</DayWrapper>;
+  return (
+    <DayWrapper today={isSameDate(dayDate, todayDate)}>
+      {date}
+      {tasks.map(({ nodeId, content }) => (
+        <DayTask key={nodeId} onClick={(e) => handleClickTask(e, nodeId)}>{`#${nodeId} ${content}`}</DayTask>
+      ))}
+    </DayWrapper>
+  );
 };
 
 export default Day;

--- a/client/src/components/organisms/ScheduleCalendar/Day.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/Day.tsx
@@ -7,10 +7,10 @@ import { DayTask, DayWrapper } from './style';
 interface IProps {
   dayDate?: { year: number; month: number; date: number };
   tasks?: IMindNode[];
+  setHoveredNode?: React.Dispatch<React.SetStateAction<IMindNode | null>>;
 }
 
-const Day: React.FC<IProps> = ({ dayDate, tasks = [] }) => {
-  const todayDate = getTodayDate();
+const Day: React.FC<IProps> = ({ dayDate, tasks = [], setHoveredNode = () => {} }) => {
   const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
 
   if (!dayDate) {
@@ -22,13 +22,30 @@ const Day: React.FC<IProps> = ({ dayDate, tasks = [] }) => {
     setSelectedNodeId(id);
   };
 
-  const { year, month, date } = dayDate;
+  const handleHoverTask = (task: IMindNode) => setHoveredNode(task);
+  const handleLeaveTask = () => setHoveredNode(null);
+
+  const { date } = dayDate;
+  const todayDate = getTodayDate();
+  const today = new Date();
+
   return (
     <DayWrapper today={isSameDate(dayDate, todayDate)}>
       {date}
-      {tasks.map(({ nodeId, content }) => (
-        <DayTask key={nodeId} onClick={(e) => handleClickTask(e, nodeId)}>{`#${nodeId} ${content}`}</DayTask>
-      ))}
+      {tasks.map((task) => {
+        const dueAt = task.dueDate ? new Date(task.dueDate) : null;
+        const endedAt = task.endDate ? new Date(task.endDate) : null;
+
+        return (
+          <DayTask
+            key={task.nodeId}
+            onClick={(e) => handleClickTask(e, task.nodeId)}
+            onMouseEnter={() => handleHoverTask(task)}
+            onMouseLeave={() => handleLeaveTask()}
+            delayed={dueAt && !endedAt && today > dueAt}
+          >{`#${task.nodeId} ${task.content}`}</DayTask>
+        );
+      })}
     </DayWrapper>
   );
 };

--- a/client/src/components/organisms/ScheduleCalendar/LayerDay.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerDay.tsx
@@ -1,0 +1,42 @@
+import { IMindNode } from 'types/mindmap';
+import { makeISODate } from 'utils/date';
+import { LayerDayWrapper } from './style';
+
+interface IProps {
+  dayDate?: { year: number; month: number; date: number };
+  task?: IMindNode | null;
+}
+
+const Day: React.FC<IProps> = ({ dayDate, task }) => {
+  if (!dayDate || !task) {
+    return <LayerDayWrapper></LayerDayWrapper>;
+  }
+
+  const ISODate = makeISODate(dayDate);
+  const taskCreatedISODate = new Date(task.createdAt!).toISOString().slice(0, 10);
+
+  const today = new Date();
+  const day = new Date(ISODate);
+  const createdAt = task.createdAt ? new Date(task.createdAt) : null;
+  const startedAt = task.startDate ? new Date(task.startDate) : null;
+  const endedAt = task.endDate ? new Date(task.endDate) : null;
+  const dueAt = task.dueDate ? new Date(task.dueDate) : null;
+
+  return (
+    <LayerDayWrapper>
+      {task.createdAt && taskCreatedISODate === ISODate ? <div className={'created'}>태스크 생성</div> : ''}
+      {task.startDate && task.startDate === ISODate ? <div className={'started'}>태스크 시작</div> : ''}
+      {task.endDate && task.endDate === ISODate ? <div className={'ended'}>태스크 종료</div> : ''}
+      {task.dueDate && task.dueDate === ISODate ? <div className={'due'}>마감 날짜</div> : ''}
+
+      {createdAt && startedAt && dueAt && day > createdAt && day < startedAt && day && day < dueAt ? <hr className={'waiting'} /> : ''}
+      {createdAt && !startedAt && dueAt && day > createdAt && day < dueAt && today > dueAt ? <hr className={'delaying'} /> : ''}
+      {startedAt && endedAt && dueAt && day > startedAt && day < endedAt && day < dueAt ? <hr className={'working'} /> : ''}
+      {startedAt && !endedAt && dueAt && day > startedAt && day < dueAt && today > dueAt ? <hr className={'delaying'} /> : ''}
+      {endedAt && dueAt && day > endedAt && day < dueAt ? <hr className={'resting'} /> : ''}
+      {!endedAt && dueAt && day > dueAt && day < today ? <hr className={'delaying'} /> : ''}
+    </LayerDayWrapper>
+  );
+};
+
+export default Day;

--- a/client/src/components/organisms/ScheduleCalendar/LayerScheduleDay.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerScheduleDay.tsx
@@ -1,21 +1,19 @@
+import { LayerTask, LayerScheduleDayWrapper } from './style';
 import { useSetRecoilState } from 'recoil';
 import { selectedNodeIdState } from 'recoil/node';
 import { IMindNode } from 'types/mindmap';
-import { getTodayDate, isSameDate } from 'utils/date';
-import { DayTask, DayWrapper } from './style';
 
 interface IProps {
   dayDate?: { year: number; month: number; date: number };
   tasks?: IMindNode[];
   setHoveredNode?: React.Dispatch<React.SetStateAction<IMindNode | null>>;
-  blur?: boolean;
 }
 
-const Day: React.FC<IProps> = ({ dayDate, tasks = [], setHoveredNode = () => {}, blur }) => {
+const LayerScheduleDay: React.FC<IProps> = ({ dayDate, tasks = [], setHoveredNode = () => {} }) => {
   const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
 
   if (!dayDate) {
-    return <DayWrapper disable={true}></DayWrapper>;
+    return <LayerScheduleDayWrapper></LayerScheduleDayWrapper>;
   }
 
   const handleClickTask = (e: React.MouseEvent, id: number) => {
@@ -26,31 +24,27 @@ const Day: React.FC<IProps> = ({ dayDate, tasks = [], setHoveredNode = () => {},
   const handleHoverTask = (task: IMindNode) => setHoveredNode(task);
   const handleLeaveTask = () => setHoveredNode(null);
 
-  const { date } = dayDate;
-  const todayDate = getTodayDate();
   const today = new Date();
 
   return (
-    <DayWrapper today={isSameDate(dayDate, todayDate)}>
-      {date}
+    <LayerScheduleDayWrapper>
       {tasks.map((task) => {
         const dueAt = task.dueDate ? new Date(task.dueDate) : null;
         const endedAt = task.endDate ? new Date(task.endDate) : null;
 
         return (
-          <DayTask
+          <LayerTask
             key={task.nodeId}
             onClick={(e) => handleClickTask(e, task.nodeId)}
             onMouseEnter={() => handleHoverTask(task)}
             onMouseLeave={() => handleLeaveTask()}
             delayed={dueAt && !endedAt && today > dueAt}
             ended={dueAt && endedAt && true}
-            blur={blur}
-          >{`#${task.nodeId} ${task.content}`}</DayTask>
+          >{`#${task.nodeId} ${task.content}`}</LayerTask>
         );
       })}
-    </DayWrapper>
+    </LayerScheduleDayWrapper>
   );
 };
 
-export default Day;
+export default LayerScheduleDay;

--- a/client/src/components/organisms/ScheduleCalendar/LayerScheduleMonth.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerScheduleMonth.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useState } from 'react';
+import LayerScheduleDay from './LayerScheduleDay';
+import { useRecoilValue } from 'recoil';
+import { filteredTaskState } from 'recoil/project';
+import { IMindNode } from 'types/mindmap';
+import { parseISODate } from 'utils/date';
+
+interface IProps {
+  currentDateISO: string;
+  setHoveredNode?: React.Dispatch<React.SetStateAction<IMindNode | null>>;
+}
+
+const LayerScheduleMonth: React.FC<IProps> = ({ currentDateISO, setHoveredNode }) => {
+  const taskList = useRecoilValue(filteredTaskState);
+  const [taskMapToDueDate, setTaskMapToDueDate] = useState<{ [ISODate: string]: IMindNode[] }>({});
+
+  const { year, month } = parseISODate(currentDateISO);
+  const prevDays = new Date(year, month - 1, 1).getDay();
+  const days = new Date(year, month, 0).getDate();
+  const nextDays = 6 - new Date(year, month, 0).getDay();
+
+  useEffect(() => {
+    const newTaskMapToDueDate: { [ISODate: string]: IMindNode[] } = {};
+    Object.values(taskList).forEach((task) => {
+      const { dueDate } = task;
+      if (!dueDate) {
+        return;
+      }
+      if (!newTaskMapToDueDate[dueDate]) {
+        newTaskMapToDueDate[dueDate] = [];
+      }
+      newTaskMapToDueDate[dueDate].push(task);
+    });
+    setTaskMapToDueDate(newTaskMapToDueDate);
+  }, [taskList]);
+
+  return (
+    <>
+      {Array(prevDays)
+        .fill(0)
+        .map((_, idx) => (
+          <LayerScheduleDay key={idx} />
+        ))}
+      {Array(days)
+        .fill(0)
+        .map((_, idx) => (
+          <LayerScheduleDay
+            key={idx}
+            dayDate={{ year, month, date: idx + 1 }}
+            tasks={taskMapToDueDate[`${year}-${month}-${idx + 1}`]}
+            setHoveredNode={setHoveredNode}
+          />
+        ))}
+      {Array(nextDays)
+        .fill(0)
+        .map((_, idx) => (
+          <LayerScheduleDay key={idx} />
+        ))}
+    </>
+  );
+};
+
+const LayerScheduleMonthMemo = React.memo(LayerScheduleMonth);
+
+export default LayerScheduleMonthMemo;

--- a/client/src/components/organisms/ScheduleCalendar/LayerSprintDay.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerSprintDay.tsx
@@ -26,20 +26,20 @@ const LayerSprintDay: React.FC<IProps> = ({ dayDate, sprints }) => {
 
   return (
     <LayerSprintDayWrapper>
-      {sprints.map(({ startDate, endDate, color }) => {
+      {sprints.map(({ id, startDate, endDate, color }) => {
         if (startDate === ISODate) {
-          return <LayerSprint className={'start'} color={color} />;
+          return <LayerSprint key={id} className={'start'} color={color} />;
         }
 
         if (endDate === ISODate) {
-          return <LayerSprint className={'end'} color={color} />;
+          return <LayerSprint key={id} className={'end'} color={color} />;
         }
 
         const startAt = new Date(startDate);
         const endAt = new Date(endDate);
 
         if (day > startAt && day < endAt) {
-          return <LayerSprint color={color} />;
+          return <LayerSprint key={id} color={color} />;
         }
       })}
     </LayerSprintDayWrapper>

--- a/client/src/components/organisms/ScheduleCalendar/LayerSprintDay.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerSprintDay.tsx
@@ -1,0 +1,49 @@
+import { ISprint } from 'types/sprint';
+import { makeISODate } from 'utils/date';
+import { LayerSprint, LayerSprintDayWrapper } from './style';
+
+interface IProps {
+  dayDate?: { year: number; month: number; date: number };
+  sprints?: ISprint[];
+}
+
+const LayerSprintDay: React.FC<IProps> = ({ dayDate, sprints }) => {
+  if (!dayDate || !sprints) {
+    return <LayerSprintDayWrapper></LayerSprintDayWrapper>;
+  }
+  sprints.sort((a, b) => {
+    const aStartAt = new Date(a.startDate);
+    const bStartAt = new Date(b.startDate);
+    if (aStartAt < bStartAt) {
+      return -1;
+    } else {
+      return 1;
+    }
+  });
+
+  const ISODate = makeISODate(dayDate);
+  const day = new Date(ISODate);
+
+  return (
+    <LayerSprintDayWrapper>
+      {sprints.map(({ startDate, endDate, color }) => {
+        if (startDate === ISODate) {
+          return <LayerSprint className={'start'} color={color} />;
+        }
+
+        if (endDate === ISODate) {
+          return <LayerSprint className={'end'} color={color} />;
+        }
+
+        const startAt = new Date(startDate);
+        const endAt = new Date(endDate);
+
+        if (day > startAt && day < endAt) {
+          return <LayerSprint color={color} />;
+        }
+      })}
+    </LayerSprintDayWrapper>
+  );
+};
+
+export default LayerSprintDay;

--- a/client/src/components/organisms/ScheduleCalendar/LayerSprintMonth.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerSprintMonth.tsx
@@ -1,8 +1,8 @@
-import { LayerWrapper } from './style';
-import { parseISODate } from 'utils/date';
+import React from 'react';
 import LayerSprintDay from './LayerSprintDay';
 import { useRecoilValue } from 'recoil';
 import { sprintListState } from 'recoil/project';
+import { parseISODate } from 'utils/date';
 
 interface IProps {
   currentDateISO: string;
@@ -16,7 +16,7 @@ const LayerSprintMonth: React.FC<IProps> = ({ currentDateISO }) => {
   const nextDays = 6 - new Date(year, month, 0).getDay();
 
   return (
-    <LayerWrapper>
+    <>
       {Array(prevDays)
         .fill(0)
         .map((_, idx) => (
@@ -32,8 +32,10 @@ const LayerSprintMonth: React.FC<IProps> = ({ currentDateISO }) => {
         .map((_, idx) => (
           <LayerSprintDay key={idx} />
         ))}
-    </LayerWrapper>
+    </>
   );
 };
 
-export default LayerSprintMonth;
+const LayerSprintMonthMemo = React.memo(LayerSprintMonth);
+
+export default LayerSprintMonthMemo;

--- a/client/src/components/organisms/ScheduleCalendar/LayerSprintMonth.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerSprintMonth.tsx
@@ -1,0 +1,39 @@
+import { LayerWrapper } from './style';
+import { parseISODate } from 'utils/date';
+import LayerSprintDay from './LayerSprintDay';
+import { useRecoilValue } from 'recoil';
+import { sprintListState } from 'recoil/project';
+
+interface IProps {
+  currentDateISO: string;
+}
+
+const LayerSprintMonth: React.FC<IProps> = ({ currentDateISO }) => {
+  const sprintList = useRecoilValue(sprintListState);
+  const { year, month } = parseISODate(currentDateISO);
+  const prevDays = new Date(year, month - 1, 1).getDay();
+  const days = new Date(year, month, 0).getDate();
+  const nextDays = 6 - new Date(year, month, 0).getDay();
+
+  return (
+    <LayerWrapper>
+      {Array(prevDays)
+        .fill(0)
+        .map((_, idx) => (
+          <LayerSprintDay key={idx} />
+        ))}
+      {Array(days)
+        .fill(0)
+        .map((_, idx) => (
+          <LayerSprintDay key={idx} dayDate={{ year, month, date: idx + 1 }} sprints={Object.values(sprintList)} />
+        ))}
+      {Array(nextDays)
+        .fill(0)
+        .map((_, idx) => (
+          <LayerSprintDay key={idx} />
+        ))}
+    </LayerWrapper>
+  );
+};
+
+export default LayerSprintMonth;

--- a/client/src/components/organisms/ScheduleCalendar/LayerTaskDetailDay.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerTaskDetailDay.tsx
@@ -1,6 +1,6 @@
+import { LayerTaskDetailDayWrapper } from './style';
 import { IMindNode } from 'types/mindmap';
 import { makeISODate } from 'utils/date';
-import { LayerDayWrapper } from './style';
 
 interface IProps {
   dayDate?: { year: number; month: number; date: number };
@@ -9,7 +9,7 @@ interface IProps {
 
 const Day: React.FC<IProps> = ({ dayDate, task }) => {
   if (!dayDate || !task) {
-    return <LayerDayWrapper></LayerDayWrapper>;
+    return <LayerTaskDetailDayWrapper></LayerTaskDetailDayWrapper>;
   }
 
   const ISODate = makeISODate(dayDate);
@@ -23,10 +23,10 @@ const Day: React.FC<IProps> = ({ dayDate, task }) => {
   const dueAt = task.dueDate ? new Date(task.dueDate) : null;
 
   return (
-    <LayerDayWrapper>
+    <LayerTaskDetailDayWrapper>
       {task.createdAt && taskCreatedISODate === ISODate ? <div className={'created'}>태스크 생성</div> : ''}
-      {task.startDate && task.startDate === ISODate ? <div className={'started'}>태스크 시작</div> : ''}
-      {task.endDate && task.endDate === ISODate ? <div className={'ended'}>태스크 종료</div> : ''}
+      {task.startDate && task.startDate === ISODate ? <div className={'started'}>작업 시작</div> : ''}
+      {task.endDate && task.endDate === ISODate ? <div className={'ended'}>작업 종료</div> : ''}
       {task.dueDate && task.dueDate === ISODate ? <div className={'due'}>마감 날짜</div> : ''}
 
       {createdAt && startedAt && dueAt && day > createdAt && day < startedAt && day && day < dueAt ? <hr className={'waiting'} /> : ''}
@@ -35,7 +35,7 @@ const Day: React.FC<IProps> = ({ dayDate, task }) => {
       {startedAt && !endedAt && dueAt && day > startedAt && day < dueAt && today > dueAt ? <hr className={'delaying'} /> : ''}
       {endedAt && dueAt && day > endedAt && day < dueAt ? <hr className={'resting'} /> : ''}
       {!endedAt && dueAt && day > dueAt && day < today ? <hr className={'delaying'} /> : ''}
-    </LayerDayWrapper>
+    </LayerTaskDetailDayWrapper>
   );
 };
 

--- a/client/src/components/organisms/ScheduleCalendar/LayerTaskDetailMonth.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerTaskDetailMonth.tsx
@@ -1,0 +1,37 @@
+import LayerTaskDetailDay from './LayerTaskDetailDay';
+import { IMindNode } from 'types/mindmap';
+import { parseISODate } from 'utils/date';
+
+interface IProps {
+  currentDateISO: string;
+  hoveredNode: IMindNode | null;
+}
+
+const LayerTaskDetailMonth: React.FC<IProps> = ({ currentDateISO, hoveredNode }) => {
+  const { year, month } = parseISODate(currentDateISO);
+  const prevDays = new Date(year, month - 1, 1).getDay();
+  const days = new Date(year, month, 0).getDate();
+  const nextDays = 6 - new Date(year, month, 0).getDay();
+
+  return (
+    <>
+      {Array(prevDays)
+        .fill(0)
+        .map((_, idx) => (
+          <LayerTaskDetailDay key={idx} />
+        ))}
+      {Array(days)
+        .fill(0)
+        .map((_, idx) => (
+          <LayerTaskDetailDay key={idx} dayDate={{ year, month, date: idx + 1 }} task={hoveredNode} />
+        ))}
+      {Array(nextDays)
+        .fill(0)
+        .map((_, idx) => (
+          <LayerTaskDetailDay key={idx} />
+        ))}
+    </>
+  );
+};
+
+export default LayerTaskDetailMonth;

--- a/client/src/components/organisms/ScheduleCalendar/MonthSelector.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/MonthSelector.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { IconButton } from 'components/molecules';
 import { arrowLeft, arrowRight } from 'img';
 import { getNextMonthISODate, getPrevMonthISODate, parseISODate } from 'utils/date';
@@ -23,4 +24,6 @@ const MonthSelector: React.FC<IProps> = ({ currentDateISO, setCurrentDateISO }) 
   );
 };
 
-export default MonthSelector;
+const MonthSelectorMemo = React.memo(MonthSelector);
+
+export default MonthSelectorMemo;

--- a/client/src/components/organisms/ScheduleCalendar/MonthSelector.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/MonthSelector.tsx
@@ -1,0 +1,26 @@
+import { IconButton } from 'components/molecules';
+import { arrowLeft, arrowRight } from 'img';
+import { getNextMonthISODate, getPrevMonthISODate, parseISODate } from 'utils/date';
+import { MonthSelectorWrapper } from './style';
+
+interface IProps {
+  currentDateISO: string;
+  setCurrentDateISO: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const MonthSelector: React.FC<IProps> = ({ currentDateISO, setCurrentDateISO }) => {
+  const { year, month } = parseISODate(currentDateISO);
+  const currentYearMonth = `${year}년 ${month}월`;
+  const handleClickNextMonth = () => setCurrentDateISO(getNextMonthISODate(currentDateISO));
+  const handleClickPrevMonth = () => setCurrentDateISO(getPrevMonthISODate(currentDateISO));
+
+  return (
+    <MonthSelectorWrapper>
+      <IconButton imgSrc={arrowLeft} onClick={handleClickPrevMonth} altText={'prev Month'} size={{ width: '50px', height: '50px' }} />
+      <span>{currentYearMonth}</span>
+      <IconButton imgSrc={arrowRight} onClick={handleClickNextMonth} altText={'prev Month'} size={{ width: '50px', height: '50px' }} />
+    </MonthSelectorWrapper>
+  );
+};
+
+export default MonthSelector;

--- a/client/src/components/organisms/ScheduleCalendar/index.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { CalendarHeader, CalendarWrapper, LayerWrapper } from './style';
+import { CalendarHeader, CalendarWrapper, LayerWrapper, Wrapper } from './style';
 import { getTodayISODate, parseISODate } from 'utils/date';
 import MonthSelector from './MonthSelector';
 import Day from './Day';
@@ -7,7 +7,6 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { filteredTaskState } from 'recoil/project';
 import { IMindNode } from 'types/mindmap';
 
-import { Wrapper } from 'components/atoms';
 import { selectedNodeIdState } from 'recoil/node';
 import LayerDay from './LayerDay';
 import LayerSprintMonth from './LayerSprintMonth';
@@ -44,7 +43,7 @@ const ScheduleCalendar = () => {
   const handleClickOutside = () => setSelectedNodeId(null);
 
   return (
-    <Wrapper flex='columnCenter' onClick={() => handleClickOutside()}>
+    <Wrapper onClick={() => handleClickOutside()}>
       <MonthSelector currentDateISO={currentDateISO} setCurrentDateISO={setCurrentDateISO} />
       <CalendarWrapper>
         {columns.map((column, idx) => (
@@ -89,7 +88,9 @@ const ScheduleCalendar = () => {
             <LayerDay key={idx} />
           ))}
       </LayerWrapper>
-      <LayerSprintMonth currentDateISO={currentDateISO} />
+      <LayerWrapper className={hoveredNode ? 'blur' : ''}>
+        <LayerSprintMonth currentDateISO={currentDateISO} />
+      </LayerWrapper>
     </Wrapper>
   );
 };

--- a/client/src/components/organisms/ScheduleCalendar/index.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/index.tsx
@@ -1,10 +1,20 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CalendarHeader, CalendarWrapper } from './style';
 import { getTodayISODate, parseISODate } from 'utils/date';
 import MonthSelector from './MonthSelector';
 import Day from './Day';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { filteredTaskState } from 'recoil/project';
+import { IMindNode } from 'types/mindmap';
+
+import { Wrapper } from 'components/atoms';
+import { selectedNodeIdState } from 'recoil/node';
 
 const ScheduleCalendar = () => {
+  const taskList = useRecoilValue(filteredTaskState);
+  const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
+
+  const [taskMapToDueDate, setTaskMapToDueDate] = useState<{ [ISODate: string]: IMindNode[] }>({});
   const [currentDateISO, setCurrentDateISO] = useState(getTodayISODate());
   const columns = ['일', '월', '화', '수', '목', '금', '토'];
   const { year, month } = parseISODate(currentDateISO);
@@ -12,8 +22,25 @@ const ScheduleCalendar = () => {
   const days = new Date(year, month, 0).getDate();
   const nextDays = 6 - new Date(year, month, 0).getDay();
 
+  useEffect(() => {
+    const newTaskMapToDueDate: { [ISODate: string]: IMindNode[] } = {};
+    Object.values(taskList).forEach((task) => {
+      const { dueDate } = task;
+      if (!dueDate) {
+        return;
+      }
+      if (!newTaskMapToDueDate[dueDate]) {
+        newTaskMapToDueDate[dueDate] = [];
+      }
+      newTaskMapToDueDate[dueDate].push(task);
+    });
+    setTaskMapToDueDate(newTaskMapToDueDate);
+  }, [taskList]);
+
+  const handleClickOutside = () => setSelectedNodeId(null);
+
   return (
-    <>
+    <Wrapper flex='columnCenter' onClick={() => handleClickOutside()}>
       <MonthSelector currentDateISO={currentDateISO} setCurrentDateISO={setCurrentDateISO} />
       <CalendarWrapper>
         {columns.map((column, idx) => (
@@ -27,7 +54,7 @@ const ScheduleCalendar = () => {
         {Array(days)
           .fill(0)
           .map((_, idx) => (
-            <Day key={idx} dayDate={{ year, month, date: idx + 1 }} />
+            <Day key={idx} dayDate={{ year, month, date: idx + 1 }} tasks={taskMapToDueDate[`${year}-${month}-${idx + 1}`]} />
           ))}
         {Array(nextDays)
           .fill(0)
@@ -35,7 +62,7 @@ const ScheduleCalendar = () => {
             <Day key={idx} />
           ))}
       </CalendarWrapper>
-    </>
+    </Wrapper>
   );
 };
 

--- a/client/src/components/organisms/ScheduleCalendar/index.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/index.tsx
@@ -4,23 +4,21 @@ import { getTodayISODate, parseISODate } from 'utils/date';
 import MonthSelector from './MonthSelector';
 import Day from './Day';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { filteredTaskState, sprintListState } from 'recoil/project';
-import { ISprint } from 'types/sprint';
+import { filteredTaskState } from 'recoil/project';
 import { IMindNode } from 'types/mindmap';
 
 import { Wrapper } from 'components/atoms';
 import { selectedNodeIdState } from 'recoil/node';
 import LayerDay from './LayerDay';
+import LayerSprintMonth from './LayerSprintMonth';
 
 const ScheduleCalendar = () => {
   const taskList = useRecoilValue(filteredTaskState);
-  const sprintList = useRecoilValue(sprintListState);
   const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
 
   const [hoveredNode, setHoveredNode] = useState<IMindNode | null>(null);
 
   const [taskMapToDueDate, setTaskMapToDueDate] = useState<{ [ISODate: string]: IMindNode[] }>({});
-  const [sprintMapToEndDate, setSprintMapToEndDate] = useState<{ [year: number]: { [month: number]: ISprint[] } }>({});
   const [currentDateISO, setCurrentDateISO] = useState(getTodayISODate());
   const columns = ['일', '월', '화', '수', '목', '금', '토'];
   const { year, month } = parseISODate(currentDateISO);
@@ -42,24 +40,6 @@ const ScheduleCalendar = () => {
     });
     setTaskMapToDueDate(newTaskMapToDueDate);
   }, [taskList]);
-
-  // 스프린트 부분 고민중
-  // useEffect(() => {
-  //   const newSprintMapToEndDate: { [year: number]: { [month: number]: ISprint[] } } = {};
-
-  //   Object.values(sprintList).forEach((sprint) => {
-  //     const sprintEndDate = parseISODate(sprint.endDate);
-
-  //     if (!newSprintMapToEndDate[sprintEndDate.year]) {
-  //       newSprintMapToEndDate[sprintEndDate.year] = {};
-  //     }
-  //     if (!newSprintMapToEndDate[sprintEndDate.year][sprintEndDate.month]) {
-  //       newSprintMapToEndDate[sprintEndDate.year][sprintEndDate.month] = [];
-  //     }
-  //     newSprintMapToEndDate[sprintEndDate.year][sprintEndDate.month].push(sprint);
-  //   });
-  //   setSprintMapToEndDate(newSprintMapToEndDate);
-  // }, [sprintList]);
 
   const handleClickOutside = () => setSelectedNodeId(null);
 
@@ -109,6 +89,7 @@ const ScheduleCalendar = () => {
             <LayerDay key={idx} />
           ))}
       </LayerWrapper>
+      <LayerSprintMonth currentDateISO={currentDateISO} />
     </Wrapper>
   );
 };

--- a/client/src/components/organisms/ScheduleCalendar/index.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/index.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+import { CalendarHeader, CalendarWrapper } from './style';
+import { getTodayISODate, parseISODate } from 'utils/date';
+import MonthSelector from './MonthSelector';
+import Day from './Day';
+
+const ScheduleCalendar = () => {
+  const [currentDateISO, setCurrentDateISO] = useState(getTodayISODate());
+  const columns = ['일', '월', '화', '수', '목', '금', '토'];
+  const { year, month } = parseISODate(currentDateISO);
+  const prevDays = new Date(year, month - 1, 1).getDay();
+  const days = new Date(year, month, 0).getDate();
+  const nextDays = 6 - new Date(year, month, 0).getDay();
+
+  return (
+    <>
+      <MonthSelector currentDateISO={currentDateISO} setCurrentDateISO={setCurrentDateISO} />
+      <CalendarWrapper>
+        {columns.map((column, idx) => (
+          <CalendarHeader key={idx}>{column}</CalendarHeader>
+        ))}
+        {Array(prevDays)
+          .fill(0)
+          .map((_, idx) => (
+            <Day key={idx} />
+          ))}
+        {Array(days)
+          .fill(0)
+          .map((_, idx) => (
+            <Day key={idx} dayDate={{ year, month, date: idx + 1 }} />
+          ))}
+        {Array(nextDays)
+          .fill(0)
+          .map((_, idx) => (
+            <Day key={idx} />
+          ))}
+      </CalendarWrapper>
+    </>
+  );
+};
+
+export default ScheduleCalendar;

--- a/client/src/components/organisms/ScheduleCalendar/index.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/index.tsx
@@ -1,44 +1,21 @@
-import { useEffect, useState } from 'react';
-import { CalendarHeader, CalendarWrapper, LayerWrapper, Wrapper } from './style';
-import { getTodayISODate, parseISODate } from 'utils/date';
+import { useState } from 'react';
+import { CalendarWrapper, LayerWrapper, Wrapper } from './style';
 import MonthSelector from './MonthSelector';
-import Day from './Day';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import { filteredTaskState } from 'recoil/project';
-import { IMindNode } from 'types/mindmap';
-
-import { selectedNodeIdState } from 'recoil/node';
-import LayerDay from './LayerDay';
+import Calendar from './Calendar';
 import LayerSprintMonth from './LayerSprintMonth';
+import LayerTaskDetailMonth from './LayerTaskDetailMonth';
+import LayerScheduleMonth from './LayerScheduleMonth';
+
+import { useSetRecoilState } from 'recoil';
+import { selectedNodeIdState } from 'recoil/node';
+import { IMindNode } from 'types/mindmap';
+import { getTodayISODate } from 'utils/date';
 
 const ScheduleCalendar = () => {
-  const taskList = useRecoilValue(filteredTaskState);
   const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
 
   const [hoveredNode, setHoveredNode] = useState<IMindNode | null>(null);
-
-  const [taskMapToDueDate, setTaskMapToDueDate] = useState<{ [ISODate: string]: IMindNode[] }>({});
   const [currentDateISO, setCurrentDateISO] = useState(getTodayISODate());
-  const columns = ['일', '월', '화', '수', '목', '금', '토'];
-  const { year, month } = parseISODate(currentDateISO);
-  const prevDays = new Date(year, month - 1, 1).getDay();
-  const days = new Date(year, month, 0).getDate();
-  const nextDays = 6 - new Date(year, month, 0).getDay();
-
-  useEffect(() => {
-    const newTaskMapToDueDate: { [ISODate: string]: IMindNode[] } = {};
-    Object.values(taskList).forEach((task) => {
-      const { dueDate } = task;
-      if (!dueDate) {
-        return;
-      }
-      if (!newTaskMapToDueDate[dueDate]) {
-        newTaskMapToDueDate[dueDate] = [];
-      }
-      newTaskMapToDueDate[dueDate].push(task);
-    });
-    setTaskMapToDueDate(newTaskMapToDueDate);
-  }, [taskList]);
 
   const handleClickOutside = () => setSelectedNodeId(null);
 
@@ -46,50 +23,16 @@ const ScheduleCalendar = () => {
     <Wrapper onClick={() => handleClickOutside()}>
       <MonthSelector currentDateISO={currentDateISO} setCurrentDateISO={setCurrentDateISO} />
       <CalendarWrapper>
-        {columns.map((column, idx) => (
-          <CalendarHeader key={idx}>{column}</CalendarHeader>
-        ))}
-        {Array(prevDays)
-          .fill(0)
-          .map((_, idx) => (
-            <Day key={idx} />
-          ))}
-        {Array(days)
-          .fill(0)
-          .map((_, idx) => (
-            <Day
-              key={idx}
-              dayDate={{ year, month, date: idx + 1 }}
-              tasks={taskMapToDueDate[`${year}-${month}-${idx + 1}`]}
-              setHoveredNode={setHoveredNode}
-              blur={hoveredNode ? true : false}
-            />
-          ))}
-        {Array(nextDays)
-          .fill(0)
-          .map((_, idx) => (
-            <Day key={idx} />
-          ))}
+        <Calendar currentDateISO={currentDateISO} />
       </CalendarWrapper>
-      <LayerWrapper>
-        {Array(prevDays)
-          .fill(0)
-          .map((_, idx) => (
-            <LayerDay key={idx} />
-          ))}
-        {Array(days)
-          .fill(0)
-          .map((_, idx) => (
-            <LayerDay key={idx} dayDate={{ year, month, date: idx + 1 }} task={hoveredNode} />
-          ))}
-        {Array(nextDays)
-          .fill(0)
-          .map((_, idx) => (
-            <LayerDay key={idx} />
-          ))}
+      <LayerWrapper className={hoveredNode ? 'blur no-click' : 'no-click'}>
+        <LayerSprintMonth currentDateISO={currentDateISO} />
       </LayerWrapper>
       <LayerWrapper className={hoveredNode ? 'blur' : ''}>
-        <LayerSprintMonth currentDateISO={currentDateISO} />
+        <LayerScheduleMonth currentDateISO={currentDateISO} setHoveredNode={setHoveredNode} />
+      </LayerWrapper>
+      <LayerWrapper className={'no-click'}>
+        <LayerTaskDetailMonth currentDateISO={currentDateISO} hoveredNode={hoveredNode} />
       </LayerWrapper>
     </Wrapper>
   );

--- a/client/src/components/organisms/ScheduleCalendar/index.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/index.tsx
@@ -83,6 +83,7 @@ const ScheduleCalendar = () => {
               dayDate={{ year, month, date: idx + 1 }}
               tasks={taskMapToDueDate[`${year}-${month}-${idx + 1}`]}
               setHoveredNode={setHoveredNode}
+              blur={hoveredNode ? true : false}
             />
           ))}
         {Array(nextDays)

--- a/client/src/components/organisms/ScheduleCalendar/style.ts
+++ b/client/src/components/organisms/ScheduleCalendar/style.ts
@@ -35,15 +35,28 @@ const CalendarHeader = styled.div`
 `;
 
 const DayWrapper = styled.div<{ disable?: boolean; today?: boolean }>`
+  position: relative;
   padding: 0.2rem;
   height: 6.8rem;
   font-size: ${({ theme }) => theme.fontSize.small};
   border-top: 1px solid ${({ theme }) => theme.color.gray3};
   border-right: 1px solid ${({ theme }) => theme.color.gray3};
+  overflow: hidden;
 
   color: ${({ today, theme }) => (today ? theme.color.primary1 : theme.color.gray1)};
   text-decoration: ${({ today }) => (today ? 'underline' : '')};
   background-color: ${({ disable, theme }) => (disable ? theme.color.gray4 : '')};
 `;
 
-export { MonthSelectorWrapper, CalendarWrapper, CalendarHeader, DayWrapper };
+const DayTask = styled.div<{ disable?: boolean; today?: boolean }>`
+  color: ${({ theme }) => theme.color.black};
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+
+  :hover {
+    background-color: ${({ theme }) => theme.color.gray4};
+  }
+`;
+
+export { MonthSelectorWrapper, CalendarWrapper, CalendarHeader, DayWrapper, DayTask };

--- a/client/src/components/organisms/ScheduleCalendar/style.ts
+++ b/client/src/components/organisms/ScheduleCalendar/style.ts
@@ -55,16 +55,18 @@ const DayWrapper = styled.div<{ disable?: boolean; today?: boolean }>`
   }};
 `;
 
-const DayTask = styled.div<{ delayed?: boolean | null }>`
+const DayTask = styled.div<{ delayed?: boolean | null; blur?: boolean }>`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 
   color: ${({ theme, delayed }) => (delayed ? theme.color.red : theme.color.black)};
+  opacity: ${({ blur }) => (blur ? 0.5 : 1)};
 
   :hover {
     color: ${({ theme }) => theme.color.white};
     background-color: ${({ theme }) => theme.color.primary1};
+    opacity: 1;
   }
 `;
 

--- a/client/src/components/organisms/ScheduleCalendar/style.ts
+++ b/client/src/components/organisms/ScheduleCalendar/style.ts
@@ -43,20 +43,90 @@ const DayWrapper = styled.div<{ disable?: boolean; today?: boolean }>`
   border-right: 1px solid ${({ theme }) => theme.color.gray3};
   overflow: hidden;
 
-  color: ${({ today, theme }) => (today ? theme.color.primary1 : theme.color.gray1)};
+  color: ${({ today, theme }) => (today ? theme.color.white : theme.color.gray1)};
   text-decoration: ${({ today }) => (today ? 'underline' : '')};
-  background-color: ${({ disable, theme }) => (disable ? theme.color.gray4 : '')};
+  background-color: ${({ disable, today, theme }) => {
+    if (disable) {
+      return theme.color.gray4;
+    }
+    if (today) {
+      return theme.color.primary1;
+    }
+    return '';
+  }};
 `;
 
-const DayTask = styled.div<{ disable?: boolean; today?: boolean }>`
-  color: ${({ theme }) => theme.color.black};
+const DayTask = styled.div<{ delayed?: boolean | null }>`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 
+  color: ${({ theme, delayed }) => (delayed ? theme.color.red : theme.color.black)};
+
   :hover {
-    background-color: ${({ theme }) => theme.color.gray4};
+    color: ${({ theme }) => theme.color.white};
+    background-color: ${({ theme }) => theme.color.primary1};
   }
 `;
 
-export { MonthSelectorWrapper, CalendarWrapper, CalendarHeader, DayWrapper, DayTask };
+const LayerWrapper = styled.div`
+  position: absolute;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  width: 60rem;
+  top: 9.7rem;
+  border-radius: 0.5rem;
+  overflow: hidden;
+  opacity: 1;
+  pointer-events: none;
+`;
+
+const LayerDayWrapper = styled.div`
+  position: relative;
+  height: 6.8rem;
+  width: 100%;
+  padding-top: 2.8rem;
+  color: ${({ theme }) => theme.color.white};
+  font-size: ${({ theme }) => theme.fontSize.small};
+  border-top: 1px solid ${({ theme }) => theme.color.gray3};
+
+  overflow: hidden;
+
+  div {
+    ${({ theme }) => theme.flex.center};
+    width: 100%;
+    height: 1.2rem;
+  }
+
+  hr {
+    margin: 0.5rem 0.1rem;
+    border-top: dotted 2.5px;
+  }
+
+  .created {
+    background-color: ${({ theme }) => theme.color.gray1};
+  }
+  .started {
+    background-color: ${({ theme }) => theme.color.primary1};
+  }
+  .ended {
+    background-color: ${({ theme }) => theme.color.primary2};
+  }
+  .due {
+    background-color: ${({ theme }) => theme.color.red};
+  }
+  .waiting {
+    color: ${({ theme }) => theme.color.gray1};
+  }
+  .working {
+    color: ${({ theme }) => theme.color.primary1};
+  }
+  .resting {
+    color: ${({ theme }) => theme.color.primary2};
+  }
+  .delaying {
+    color: ${({ theme }) => theme.color.red};
+  }
+`;
+
+export { MonthSelectorWrapper, CalendarWrapper, CalendarHeader, DayWrapper, DayTask, LayerWrapper, LayerDayWrapper };

--- a/client/src/components/organisms/ScheduleCalendar/style.ts
+++ b/client/src/components/organisms/ScheduleCalendar/style.ts
@@ -2,8 +2,15 @@ import styled from '@emotion/styled';
 
 const Wrapper = styled.div`
   ${({ theme }) => theme.flex.columnCenter};
+
+  font-size: ${({ theme }) => theme.fontSize.small};
+  font-weight: bold;
+
   .blur {
     opacity: 0.5;
+  }
+  .no-click {
+    pointer-events: none;
   }
 `;
 
@@ -26,6 +33,7 @@ const CalendarWrapper = styled.div`
   width: 60rem;
   margin: 1.5rem 0 1rem 0;
   background-color: ${({ theme }) => theme.color.white};
+  border-left: 1px solid ${({ theme }) => theme.color.gray3};
   border-radius: 0.5rem;
   overflow: hidden;
   ${({ theme }) => theme.shadow};
@@ -35,17 +43,14 @@ const CalendarHeader = styled.div`
   ${({ theme }) => theme.flex.center};
   height: 2rem;
   color: ${({ theme }) => theme.color.white};
-  font-size: ${({ theme }) => theme.fontSize.small};
-  font-weight: bold;
   background-color: ${({ theme }) => theme.color.primary1};
   border-right: 1px solid ${({ theme }) => theme.color.gray3};
 `;
 
-const DayWrapper = styled.div<{ disable?: boolean; today?: boolean }>`
+const CalendarDay = styled.div<{ disable?: boolean; today?: boolean }>`
   position: relative;
-  padding: 0.2rem;
   height: 6.8rem;
-  font-size: ${({ theme }) => theme.fontSize.small};
+  padding: 0.2rem;
   border-top: 1px solid ${({ theme }) => theme.color.gray3};
   border-right: 1px solid ${({ theme }) => theme.color.gray3};
   overflow: hidden;
@@ -62,11 +67,37 @@ const DayWrapper = styled.div<{ disable?: boolean; today?: boolean }>`
   }};
 `;
 
-const DayTask = styled.div<{ delayed?: boolean | null; ended?: boolean | null; blur?: boolean }>`
+const LayerWrapper = styled.div`
+  position: absolute;
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  width: 60rem;
+  top: 9.6rem;
+
+  font-size: ${({ theme }) => theme.fontSize.small};
   font-weight: bold;
-  overflow: hidden;
   white-space: nowrap;
+
+  border-radius: 0.5rem;
+  overflow: hidden;
+`;
+
+const LayerDay = styled.div`
+  position: relative;
+  height: 6.8rem;
+  border-top: 1px solid #00000000;
+
+  overflow: hidden;
+`;
+
+const LayerScheduleDayWrapper = styled(LayerDay)`
+  padding: 0.2rem;
+  padding-top: 1.1rem;
+`;
+
+const LayerTask = styled.div<{ delayed?: boolean | null; ended?: boolean | null }>`
   text-overflow: ellipsis;
+  overflow: hidden;
   cursor: pointer;
 
   color: ${({ theme, delayed, ended }) => {
@@ -76,38 +107,18 @@ const DayTask = styled.div<{ delayed?: boolean | null; ended?: boolean | null; b
     if (ended) {
       return theme.color.primary1;
     }
-    return '';
+    return theme.color.gray1;
   }};
-  opacity: ${({ blur }) => (blur ? 0.5 : 1)};
 
   :hover {
     color: ${({ theme }) => theme.color.white};
     background-color: ${({ theme }) => theme.color.primary1};
-    opacity: 1;
   }
 `;
 
-const LayerWrapper = styled.div`
-  position: absolute;
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  width: 60rem;
-  top: 9.7rem;
-  border-radius: 0.5rem;
-  overflow: hidden;
-  pointer-events: none;
-`;
-
-const LayerDayWrapper = styled.div`
-  position: relative;
-  height: 6.8rem;
-  width: 100%;
+const LayerTaskDetailDayWrapper = styled(LayerDay)`
   padding-top: 2.8rem;
   color: ${({ theme }) => theme.color.white};
-  font-size: ${({ theme }) => theme.fontSize.small};
-  border-top: 1px solid ${({ theme }) => theme.color.gray3};
-
-  overflow: hidden;
 
   div {
     ${({ theme }) => theme.flex.center};
@@ -147,12 +158,7 @@ const LayerDayWrapper = styled.div`
   }
 `;
 
-const LayerSprintDayWrapper = styled.div`
-  position: relative;
-  height: 6.8rem;
-  color: ${({ theme }) => theme.color.black};
-  font-size: ${({ theme }) => theme.fontSize.small};
-  border-top: 1px solid ${({ theme }) => theme.color.gray3};
+const LayerSprintDayWrapper = styled(LayerDay)`
   opacity: 0.2;
 
   .start {
@@ -176,10 +182,11 @@ export {
   MonthSelectorWrapper,
   CalendarWrapper,
   CalendarHeader,
-  DayWrapper,
-  DayTask,
+  CalendarDay,
   LayerWrapper,
-  LayerDayWrapper,
+  LayerScheduleDayWrapper,
+  LayerTask,
+  LayerTaskDetailDayWrapper,
   LayerSprintDayWrapper,
   LayerSprint,
 };

--- a/client/src/components/organisms/ScheduleCalendar/style.ts
+++ b/client/src/components/organisms/ScheduleCalendar/style.ts
@@ -1,5 +1,12 @@
 import styled from '@emotion/styled';
 
+const Wrapper = styled.div`
+  ${({ theme }) => theme.flex.columnCenter};
+  .blur {
+    opacity: 0.5;
+  }
+`;
+
 const MonthSelectorWrapper = styled.div`
   ${({ theme }) => theme.flex.center};
   margin-top: 3rem;
@@ -88,7 +95,6 @@ const LayerWrapper = styled.div`
   top: 9.7rem;
   border-radius: 0.5rem;
   overflow: hidden;
-  opacity: 1;
   pointer-events: none;
 `;
 
@@ -107,6 +113,7 @@ const LayerDayWrapper = styled.div`
     ${({ theme }) => theme.flex.center};
     width: 100%;
     height: 1.2rem;
+    border-radius: 0.5rem;
   }
 
   hr {
@@ -165,6 +172,7 @@ const LayerSprint = styled.div<{ color: string }>`
 `;
 
 export {
+  Wrapper,
   MonthSelectorWrapper,
   CalendarWrapper,
   CalendarHeader,

--- a/client/src/components/organisms/ScheduleCalendar/style.ts
+++ b/client/src/components/organisms/ScheduleCalendar/style.ts
@@ -56,9 +56,11 @@ const DayWrapper = styled.div<{ disable?: boolean; today?: boolean }>`
 `;
 
 const DayTask = styled.div<{ delayed?: boolean | null; ended?: boolean | null; blur?: boolean }>`
+  font-weight: bold;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
+  cursor: pointer;
 
   color: ${({ theme, delayed, ended }) => {
     if (delayed) {
@@ -138,4 +140,38 @@ const LayerDayWrapper = styled.div`
   }
 `;
 
-export { MonthSelectorWrapper, CalendarWrapper, CalendarHeader, DayWrapper, DayTask, LayerWrapper, LayerDayWrapper };
+const LayerSprintDayWrapper = styled.div`
+  position: relative;
+  height: 6.8rem;
+  color: ${({ theme }) => theme.color.black};
+  font-size: ${({ theme }) => theme.fontSize.small};
+  border-top: 1px solid ${({ theme }) => theme.color.gray3};
+  opacity: 0.2;
+
+  .start {
+    border-top-left-radius: 0.5rem;
+    border-bottom-left-radius: 0.5rem;
+  }
+  .end {
+    border-top-right-radius: 0.5rem;
+    border-bottom-right-radius: 0.5rem;
+  }
+`;
+
+const LayerSprint = styled.div<{ color: string }>`
+  width: 100%;
+  height: 1rem;
+  background-color: ${({ color }) => `#${color}`}; ;
+`;
+
+export {
+  MonthSelectorWrapper,
+  CalendarWrapper,
+  CalendarHeader,
+  DayWrapper,
+  DayTask,
+  LayerWrapper,
+  LayerDayWrapper,
+  LayerSprintDayWrapper,
+  LayerSprint,
+};

--- a/client/src/components/organisms/ScheduleCalendar/style.ts
+++ b/client/src/components/organisms/ScheduleCalendar/style.ts
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+
+const MonthSelectorWrapper = styled.div`
+  ${({ theme }) => theme.flex.center};
+  margin-top: 3rem;
+  color: ${({ theme }) => theme.color.primary2};
+  font-size: ${({ theme }) => theme.fontSize.title};
+  font-weight: bold;
+
+  span {
+    ${({ theme }) => theme.flex.center};
+    width: 20rem;
+  }
+`;
+
+const CalendarWrapper = styled.div`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  width: 60rem;
+  margin: 1.5rem 0 1rem 0;
+  background-color: ${({ theme }) => theme.color.white};
+  border-radius: 0.5rem;
+  overflow: hidden;
+  ${({ theme }) => theme.shadow};
+`;
+
+const CalendarHeader = styled.div`
+  ${({ theme }) => theme.flex.center};
+  height: 2rem;
+  color: ${({ theme }) => theme.color.white};
+  font-size: ${({ theme }) => theme.fontSize.small};
+  font-weight: bold;
+  background-color: ${({ theme }) => theme.color.primary1};
+  border-right: 1px solid ${({ theme }) => theme.color.gray3};
+`;
+
+const DayWrapper = styled.div<{ disable?: boolean; today?: boolean }>`
+  padding: 0.2rem;
+  height: 6.8rem;
+  font-size: ${({ theme }) => theme.fontSize.small};
+  border-top: 1px solid ${({ theme }) => theme.color.gray3};
+  border-right: 1px solid ${({ theme }) => theme.color.gray3};
+
+  color: ${({ today, theme }) => (today ? theme.color.primary1 : theme.color.gray1)};
+  text-decoration: ${({ today }) => (today ? 'underline' : '')};
+  background-color: ${({ disable, theme }) => (disable ? theme.color.gray4 : '')};
+`;
+
+export { MonthSelectorWrapper, CalendarWrapper, CalendarHeader, DayWrapper };

--- a/client/src/components/organisms/ScheduleCalendar/style.ts
+++ b/client/src/components/organisms/ScheduleCalendar/style.ts
@@ -43,14 +43,13 @@ const DayWrapper = styled.div<{ disable?: boolean; today?: boolean }>`
   border-right: 1px solid ${({ theme }) => theme.color.gray3};
   overflow: hidden;
 
-  color: ${({ today, theme }) => (today ? theme.color.white : theme.color.gray1)};
-  text-decoration: ${({ today }) => (today ? 'underline' : '')};
+  color: ${({ today, theme }) => (today ? theme.color.primary1 : theme.color.gray1)};
   background-color: ${({ disable, today, theme }) => {
     if (disable) {
       return theme.color.gray4;
     }
     if (today) {
-      return theme.color.primary1;
+      return theme.color.primary3;
     }
     return '';
   }};

--- a/client/src/components/organisms/ScheduleCalendar/style.ts
+++ b/client/src/components/organisms/ScheduleCalendar/style.ts
@@ -55,12 +55,20 @@ const DayWrapper = styled.div<{ disable?: boolean; today?: boolean }>`
   }};
 `;
 
-const DayTask = styled.div<{ delayed?: boolean | null; blur?: boolean }>`
+const DayTask = styled.div<{ delayed?: boolean | null; ended?: boolean | null; blur?: boolean }>`
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 
-  color: ${({ theme, delayed }) => (delayed ? theme.color.red : theme.color.black)};
+  color: ${({ theme, delayed, ended }) => {
+    if (delayed) {
+      return theme.color.red;
+    }
+    if (ended) {
+      return theme.color.primary1;
+    }
+    return '';
+  }};
   opacity: ${({ blur }) => (blur ? 0.5 : 1)};
 
   :hover {

--- a/client/src/components/organisms/index.tsx
+++ b/client/src/components/organisms/index.tsx
@@ -15,6 +15,7 @@ export { default as Header } from 'components/organisms/Header';
 export { default as HistoryBar } from 'components/organisms/HistoryBar';
 export { default as UserList } from 'components/organisms/UserList';
 export { default as HistoryBackground } from 'components/organisms/HistoryBackground';
+export { default as ScheduleCalendar } from 'components/organisms/ScheduleCalendar';
 export { default as TaskCard } from 'components/organisms/TaskCard';
 export { default as HistoryHeader } from 'components/organisms/HistoryHeader';
 export { default as UserInProgressList } from 'components/organisms/UserInProgressList';

--- a/client/src/components/templates/CommonLayout/style.ts
+++ b/client/src/components/templates/CommonLayout/style.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 export const Template = styled.div`
   position: relative;
   width: 100%;
-  height: 100vh;
+  min-height: 100vh;
   background-color: ${({ theme }) => theme.color.bgWhite};
 `;
 

--- a/client/src/img/arrow-left.svg
+++ b/client/src/img/arrow-left.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M15 18L9 12L15 6" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/img/arrow-right.svg
+++ b/client/src/img/arrow-right.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9 18L15 12L9 6" stroke="#111111" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/client/src/img/index.ts
+++ b/client/src/img/index.ts
@@ -1,3 +1,5 @@
+import arrowLeftPath from './arrow-left.svg';
+import arrowRightPath from './arrow-right.svg';
 import sharePath from './share.svg';
 import logoPath from './logo.png';
 import logoBigPath from './logo-big.png';
@@ -22,6 +24,8 @@ import sirenRedPath from './siren-red.svg';
 import pauseBtnPath from './pauseBtn.svg';
 import primaryPlusCirclePath from './primaryPlusCircle.svg';
 
+export const arrowLeft: string = arrowLeftPath;
+export const arrowRight: string = arrowRightPath;
 export const share: string = sharePath;
 export const logo: string = logoPath;
 export const logoBig: string = logoBigPath;

--- a/client/src/pages/Backlog/index.tsx
+++ b/client/src/pages/Backlog/index.tsx
@@ -1,10 +1,13 @@
+import { Wrapper } from 'components/atoms';
 import { BacklogTable } from 'components/organisms';
 import CommonLayout from 'components/templates/CommonLayout';
 
 const Backlog = () => {
   return (
     <CommonLayout>
-      <BacklogTable />
+      <Wrapper flex={'columnCenter'}>
+        <BacklogTable />
+      </Wrapper>
     </CommonLayout>
   );
 };

--- a/client/src/pages/Calendar/index.tsx
+++ b/client/src/pages/Calendar/index.tsx
@@ -1,13 +1,10 @@
-import { Wrapper } from 'components/atoms';
 import { ScheduleCalendar } from 'components/organisms';
 import { CommonLayout } from 'components/templates';
 
 const Calendar = () => {
   return (
     <CommonLayout>
-      <Wrapper flex={'columnCenter'}>
-        <ScheduleCalendar />
-      </Wrapper>
+      <ScheduleCalendar />
     </CommonLayout>
   );
 };

--- a/client/src/pages/Calendar/index.tsx
+++ b/client/src/pages/Calendar/index.tsx
@@ -1,5 +1,15 @@
+import { Wrapper } from 'components/atoms';
+import { ScheduleCalendar } from 'components/organisms';
+import { CommonLayout } from 'components/templates';
+
 const Calendar = () => {
-  return <div>캘린더페이지</div>;
+  return (
+    <CommonLayout>
+      <Wrapper flex={'columnCenter'}>
+        <ScheduleCalendar />
+      </Wrapper>
+    </CommonLayout>
+  );
 };
 
 export default Calendar;

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -11,6 +11,8 @@ const getTodayDate = () => {
 
 const isSameDate = (A: IDate, B: IDate) => A.year === B.year && A.month === B.month && A.date === B.date;
 
+const makeISODate = ({ year, month, date }: IDate) => `${year}-${month < 10 ? '0' + month : month}-${date < 10 ? '0' + date : date}`;
+
 const getTodayISODate = () => new Date().toISOString().slice(0, 10);
 
 const parseISODate = (ISODate: string) => {
@@ -28,4 +30,4 @@ const getPrevMonthISODate = (ISODate: string) => {
   return new Date(year, month - 1).toISOString().slice(0, 10);
 };
 
-export { getTodayDate, isSameDate, getTodayISODate, parseISODate, getNextMonthISODate, getPrevMonthISODate };
+export { getTodayDate, isSameDate, makeISODate, getTodayISODate, parseISODate, getNextMonthISODate, getPrevMonthISODate };

--- a/client/src/utils/date.ts
+++ b/client/src/utils/date.ts
@@ -1,0 +1,31 @@
+interface IDate {
+  year: number;
+  month: number;
+  date: number;
+}
+
+const getTodayDate = () => {
+  const today = new Date();
+  return { year: today.getFullYear(), month: today.getMonth() + 1, date: today.getDate() };
+};
+
+const isSameDate = (A: IDate, B: IDate) => A.year === B.year && A.month === B.month && A.date === B.date;
+
+const getTodayISODate = () => new Date().toISOString().slice(0, 10);
+
+const parseISODate = (ISODate: string) => {
+  const [year, month, date] = ISODate.split('-').map((x) => Number(x));
+  return { year, month, date };
+};
+
+const getNextMonthISODate = (ISODate: string) => {
+  const { year, month } = parseISODate(ISODate);
+  return new Date(year, month + 1).toISOString().slice(0, 10);
+};
+
+const getPrevMonthISODate = (ISODate: string) => {
+  const { year, month } = parseISODate(ISODate);
+  return new Date(year, month - 1).toISOString().slice(0, 10);
+};
+
+export { getTodayDate, isSameDate, getTodayISODate, parseISODate, getNextMonthISODate, getPrevMonthISODate };


### PR DESCRIPTION
## 📑 제목
캘린더 페이지

## 📎 관련 이슈
- #152

## ✔️ 셀프 체크리스트
- [ x ] 달력 컴포넌트
- [ x ] 오늘 위치 기능
- [ x ] 태스크 상세 정보를 달력에서 보는 기능
- [ x ] 스프린트들을 달력에서 보는 기능
- [  ] 드래그로 마감 날짜 변경 기능

## 💬 작업 내용
달력 컴포넌트
달력에 정보들 레이어 방식으로 진행
useMemo 렌더링 최적화

![녹화_2021_11_24_18_44_53_413](https://user-images.githubusercontent.com/73219421/143215433-10a92c8f-7739-4190-8c2e-7d19d7ebba33.gif)

## 🚧 PR 특이 사항
라인(스프린트 등)을 어떻게 그릴까 방식을 고민하다 결국 날짜 칸으로 이루어진 레이어를 구현했습니다.
스프린트를 위해 30일 날짜에 매번 스프린트 리스트를 검사합니다.

따라서 너무 많은 렌더링이 걱정이되서 렌더링 최적화를 했습니다.
월이 바뀌거나, 새로운 태스크, 스프린트(얘네 둘 레이어도 분리함)가 추가 되지 않는 이상 렌더링 되지않습니다.


## 🕰 실제 소요 시간
15h 