### PR TITLE
sample project 생성을 도와주는 api

### DIFF
--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -3,6 +3,7 @@ import authRouter from './auth';
 import userRouter from './user';
 import projectRouter from './project';
 import historyRouter from './history';
+import sampleRouter from './sample';
 
 const router = Router();
 
@@ -10,5 +11,6 @@ router.use('/auth', authRouter);
 router.use('/user', userRouter);
 router.use('/project', projectRouter);
 router.use('/history', historyRouter);
+router.use('/sample', sampleRouter);
 
 export default router;

--- a/server/src/routes/sample.ts
+++ b/server/src/routes/sample.ts
@@ -1,0 +1,29 @@
+import { Router, Request, Response } from 'express';
+import { verifyToken } from '../middlewares/auth';
+import { identifyUser } from '../middlewares/user';
+import { addUserToProject } from '../services/project';
+import { convertEvent, convertHistoryEvent } from '../utils/event-converter';
+const router = Router();
+
+router.post('/', verifyToken, identifyUser, async (req: Request, res: Response) => {
+  const { type, projectId, data } = req.body;
+  const eventData = ['type', type, 'project', projectId, 'user', res.locals.user.id, 'data', data];
+  const eventType = ['ADD_SPRINT', 'ADD_LABEL', 'DELETE_SPRINT', 'DELETE_LABEL'];
+  const historyEventType = ['ADD_NODE', 'DELETE_NODE', 'UPDATE_NODE_PARENT', 'UPDATE_NODE_CONTENT', 'UPDATE_TASK_INFORMATION'];
+  if (eventType.includes(type)) {
+    const dbData = await convertEvent(eventData);
+    res.status(200).send(dbData);
+  }
+  if (historyEventType.includes(type)) {
+    const dbData = await convertHistoryEvent(eventData);
+    res.status(200).send(JSON.stringify(dbData));
+  }
+});
+
+router.post('/user-project', async (req: Request, res: Response) => {
+  const { userId, projectId } = req.body;
+  const dbData = await addUserToProject(userId, projectId);
+  res.status(200).send(JSON.stringify(dbData));
+});
+
+export default router;

--- a/server/src/utils/event-converter.ts
+++ b/server/src/utils/event-converter.ts
@@ -53,7 +53,6 @@ const eventFunction = (): Record<eventType.TEventType, TEventFunction> => {
     },
     DELETE_SPRINT: (data) => {
       const { sprintId } = data as eventType.TDeleteSprint;
-      console.log(sprintId);
       deleteSprint(sprintId);
       return;
     },


### PR DESCRIPTION
## 📑 제목
sample project 생성을 도와주는 api
## 📎 관련 이슈

## ✔️ 셀프 체크리스트

## 💬 작업 내용
뭐든 귀찮을 거 같아서 postman으로 하기로 했다.

## 🚧 PR 특이 사항
- [postman](https://go.postman.co/workspace/My-Workspace~19cc752e-35ed-43f6-8d33-5fa8174391a6/collection/15186768-9f0ff09e-1f78-4df7-ac28-88c49b1821f2)
- 뭐든 하려면 노드 id가 있어야 해서 스크립트로는 도무지 어려워 보였음.
- 여기서 데이터 내용만 바꿔서 날리면 되는데 다른 건 별로 안 귀찮은데 task info가 귀찮다.
- 마인드맵 페이지에서 에픽,스토리,태스크로 노드들 나누는거랑 태스크에다가 스프린트 ,담당자, 마감날짜, 예상시간, 중요도 할당하는 건 직접하는 게 좋아 보임.
- 태스크 상태, 시작 날짜, 끝 날짜, 걸린 시간은 postman으로 해야 하는게, 날짜를 조작해야 캘린더에 이쁘게 나올 듯
- api를 통한 거라 히스토리는 안 남음
- 로컬에서 좀 하다가 그냥 라이브서버에서 마저 하기로 했음
## 🕰 실제 소요 시간
