### PR TITLE
Task 완료도 및 우선순위 차트 구현 & 사용자 노드 포커싱 소켓 이벤트 구현

### DIFF
--- a/client/src/components/atoms/NodeTag/index.tsx
+++ b/client/src/components/atoms/NodeTag/index.tsx
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+const NodeTag = styled.div`
+  color: ${({ theme }) => theme.color.white};
+  font-size: ${({ theme }) => theme.fontSize.small};
+  border-radius: 1rem;
+  padding: 0.2rem;
+`;
+
+export default NodeTag;

--- a/client/src/components/atoms/index.tsx
+++ b/client/src/components/atoms/index.tsx
@@ -14,3 +14,4 @@ export { default as UserIcon } from 'components/atoms/UserIcon';
 export { default as DragTarget } from 'components/atoms/DragTarget';
 export { default as Wrapper } from 'components/atoms/Wrapper';
 export { default as PriorityIcon } from 'components/atoms/PriorityIcon';
+export { default as NodeTag } from 'components/atoms/NodeTag';

--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -1,7 +1,7 @@
 import React, { FormEvent, useEffect, useRef, useState } from 'react';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { Node, PriorityIcon, UserIcon } from 'components/atoms';
-import { Path, TempNode } from 'components/molecules';
+import { Path, TempNode, UserFocusBox } from 'components/molecules';
 import { ITaskFilters } from 'components/organisms/MindmapTree';
 import { NodeContainer, ChildContainer, NodeDeleteBtn } from './style';
 import { getNextMapState, mindmapState, TEMP_NODE_ID } from 'recoil/mindmap';
@@ -10,7 +10,7 @@ import { currentHistoryNodeIdState, isHistoryOpenState } from 'recoil/history';
 import useHistoryEmitter from 'hooks/useHistoryEmitter';
 import { TCoord, TRect, getCurrentCoord, getGap, getType, calcRect, Levels } from 'utils/helpers';
 import { IMindmapData, IMindNode, IMindNodes } from 'types/mindmap';
-import { assigneeFilterState, labelFilterState, sprintFilterState, userListState } from 'recoil/project';
+import { assigneeFilterState, labelFilterState, sprintFilterState, userFocusNodeState, userListState } from 'recoil/project';
 
 interface ITreeProps {
   nodeId: number;
@@ -70,6 +70,12 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId
   };
   const userList = useRecoilValue(userListState);
   const isHistoryOpen = useRecoilValue(isHistoryOpenState);
+  const userFocusNode = useRecoilValue(userFocusNodeState);
+
+  const focusingUsers = Array.from(userFocusNode.entries())
+    .filter(([_, id]) => id === nodeId)
+    .map(([userId, _]) => userList[userId])
+    .slice(0, 3);
   const isFiltering = !!Object.values(taskFilters).reduce((acc, filter) => (acc += filter ? filter : ''), '');
 
   const { addNode } = useHistoryEmitter();
@@ -175,6 +181,7 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId
             {!isHistoryOpen && !isRoot && isSelected && (
               <NodeDeleteBtn onClick={handleDeleteBtnClick.bind(null, parentId!, node)}>삭제</NodeDeleteBtn>
             )}
+            <UserFocusBox users={focusingUsers} />
             {content}
           </Node>
         </>

--- a/client/src/components/molecules/Tree/style.tsx
+++ b/client/src/components/molecules/Tree/style.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { NodeTag } from 'components/atoms';
 
 interface IStyleProps {
   isRoot: boolean;
@@ -17,12 +18,8 @@ export const ChildContainer = styled.div`
   gap: 1rem;
 `;
 
-export const NodeDeleteBtn = styled.div`
-  color: ${({ theme }) => theme.color.white};
+export const NodeDeleteBtn = styled(NodeTag)`
   background: ${({ theme }) => theme.color.primary2};
-  font-size: ${({ theme }) => theme.fontSize.small};
-  border-radius: 1rem;
-  padding: 0.2rem;
   position: absolute;
   right: 0;
   top: 0;

--- a/client/src/components/molecules/UserFocusBox/index.tsx
+++ b/client/src/components/molecules/UserFocusBox/index.tsx
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled';
+import { NodeTag } from 'components/atoms';
+import { IUser } from 'types/user';
+
+interface IProps {
+  users: Array<IUser>;
+}
+interface IFocusProps {
+  userColor: string;
+}
+
+const Container = styled.div`
+  ${({ theme }) => theme.flex.row};
+  position: absolute;
+  left: -10%;
+  top: 0;
+  transform: translateY(-50%);
+`;
+
+const UserFocusTag = styled(NodeTag)<IFocusProps>`
+  background: ${({ userColor }) => '#' + userColor};
+`;
+
+const UserFocusBox: React.FC<IProps> = ({ users }) => {
+  return (
+    <>
+      <Container>
+        {users.map(({ id, color, name }) => (
+          <UserFocusTag key={id} userColor={color}>
+            {name}
+          </UserFocusTag>
+        ))}
+      </Container>
+    </>
+  );
+};
+
+export default UserFocusBox;

--- a/client/src/components/molecules/index.tsx
+++ b/client/src/components/molecules/index.tsx
@@ -15,3 +15,4 @@ export { default as HistoryWindow } from 'components/molecules/HistoryWindow';
 export { default as TempNode } from 'components/molecules/TempNode';
 export { default as TaskInfo } from 'components/molecules/TaskInfo';
 export { default as LabelIcon } from 'components/molecules/LabelIcon';
+export { default as UserFocusBox } from 'components/molecules/UserFocusBox';

--- a/client/src/components/organisms/DoneTaskChart/index.tsx
+++ b/client/src/components/organisms/DoneTaskChart/index.tsx
@@ -7,9 +7,13 @@ import { doneTaskChartState } from 'recoil/chart';
 import { assigneeFilterState, sprintFilterState } from 'recoil/project';
 
 const DoneTaskChart = () => {
+  const history = useHistory();
+  const projectId = useProjectId();
+  const setAssigneeFilter = useSetRecoilState(assigneeFilterState);
+  const setSprintFilter = useSetRecoilState(sprintFilterState);
   const doneTaskData = useRecoilValue(doneTaskChartState);
 
-  const { categories, series } = doneTaskData;
+  const { categories, series, dictSprintname, dictUsername } = doneTaskData;
   const copiedSeries = Object.values(series).map((elem) => ({ ...elem, data: [...elem.data] }));
 
   const options = {
@@ -59,6 +63,21 @@ const DoneTaskChart = () => {
     plotOptions: {
       column: {
         stacking: 'normal',
+        point: {
+          events: {
+            click: function (this: { category: string; series: Highcharts.Series }) {
+              const {
+                category,
+                series: { name },
+              } = this;
+              const sprintId = dictSprintname[category?.split('<')[0]];
+              const assigneeId = dictUsername[name];
+              setSprintFilter(sprintId);
+              if (assigneeId) setAssigneeFilter(assigneeId);
+              history.push('/backlog/' + projectId);
+            },
+          },
+        },
       },
       series: {
         cursor: 'pointer',

--- a/client/src/components/organisms/DoneTaskChart/index.tsx
+++ b/client/src/components/organisms/DoneTaskChart/index.tsx
@@ -1,0 +1,55 @@
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { doneTaskChartState } from 'recoil/chart';
+
+const DoneTaskChart = () => {
+  const doneTaskData = useRecoilValue(doneTaskChartState);
+
+  const { categories, series } = doneTaskData;
+  const copiedSeries = Object.values(series).map((elem) => ({ ...elem, data: [...elem.data] }));
+
+  const options = {
+    chart: {
+      type: 'column',
+    },
+
+    title: {
+      text: '속도 차트',
+    },
+
+    xAxis: {
+      type: 'sprint',
+      categories: categories,
+    },
+    yAxis: {
+      allowDecimals: false,
+      min: 0,
+      title: {
+        text: 'Tasks',
+      },
+      stackLabels: {
+        enabled: true,
+      },
+    },
+
+    plotOptions: {
+      column: {
+        stacking: 'normal',
+      },
+      series: {
+        cursor: 'pointer',
+      },
+    },
+
+    series: copiedSeries,
+  };
+
+  return (
+    <>
+      <HighchartsReact highcharts={Highcharts} options={options} />
+    </>
+  );
+};
+
+export default DoneTaskChart;

--- a/client/src/components/organisms/DoneTaskChart/index.tsx
+++ b/client/src/components/organisms/DoneTaskChart/index.tsx
@@ -1,7 +1,10 @@
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
+import useProjectId from 'hooks/useRoomId';
+import { useHistory } from 'react-router';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { doneTaskChartState } from 'recoil/chart';
+import { assigneeFilterState, sprintFilterState } from 'recoil/project';
 
 const DoneTaskChart = () => {
   const doneTaskData = useRecoilValue(doneTaskChartState);
@@ -30,6 +33,26 @@ const DoneTaskChart = () => {
       },
       stackLabels: {
         enabled: true,
+      },
+    },
+
+    tooltip: {
+      formatter: function (this: Highcharts.TooltipFormatterContextObject): string {
+        const sprintName = this.x;
+        const seriesName = this.series.name;
+        const taskNum = this.y;
+        const isSprintTotal = seriesName === '주차 별 할당';
+        const totalTask = isSprintTotal ? series.entire.total : series[seriesName].total;
+        return isSprintTotal
+          ? `
+        <b>${sprintName}</b><br/><br/>
+        전체 TASK 수: ${taskNum}
+        `
+          : `
+        <b>* ${seriesName}</b><br/><br/>
+        TASK 처리 수 : ${taskNum}<br/>
+        평균 처리 수: ${(totalTask / categories.length).toFixed(2)}<br/>
+        `;
       },
     },
 

--- a/client/src/components/organisms/DoneTaskChart/index.tsx
+++ b/client/src/components/organisms/DoneTaskChart/index.tsx
@@ -1,6 +1,7 @@
 import Highcharts from 'highcharts';
 import HighchartsReact from 'highcharts-react-official';
 import useProjectId from 'hooks/useRoomId';
+import useToast from 'hooks/useToast';
 import { useHistory } from 'react-router';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { doneTaskChartState } from 'recoil/chart';
@@ -9,6 +10,7 @@ import { assigneeFilterState, sprintFilterState } from 'recoil/project';
 const DoneTaskChart = () => {
   const history = useHistory();
   const projectId = useProjectId();
+  const { showMessage } = useToast();
   const setAssigneeFilter = useSetRecoilState(assigneeFilterState);
   const setSprintFilter = useSetRecoilState(sprintFilterState);
   const doneTaskData = useRecoilValue(doneTaskChartState);
@@ -22,7 +24,7 @@ const DoneTaskChart = () => {
     },
 
     title: {
-      text: '속도 차트',
+      text: '태스크 완료도',
     },
 
     xAxis: {
@@ -70,10 +72,12 @@ const DoneTaskChart = () => {
                 category,
                 series: { name },
               } = this;
-              const sprintId = dictSprintname[category?.split('<')[0]];
+              const sprintName = category?.split('<')[0];
+              const sprintId = dictSprintname[sprintName];
               const assigneeId = dictUsername[name];
               setSprintFilter(sprintId);
               if (assigneeId) setAssigneeFilter(assigneeId);
+              showMessage(`필터링: ${sprintName} ${assigneeId ? '유저명: ' + assigneeId : ''}`);
               history.push('/backlog/' + projectId);
             },
           },

--- a/client/src/components/organisms/PriorityChart/index.tsx
+++ b/client/src/components/organisms/PriorityChart/index.tsx
@@ -1,0 +1,52 @@
+import drilldown from 'highcharts/modules/drilldown';
+import Highcharts from 'highcharts';
+import HighchartsReact from 'highcharts-react-official';
+import { useRecoilValue } from 'recoil';
+import { priorityChartState } from 'recoil/chart';
+drilldown(Highcharts);
+
+const PriorityChart = () => {
+  const priorityData = useRecoilValue(priorityChartState);
+  const { series, drilldownSeries } = priorityData;
+  const copiedSeries = Object.values(series).map((elem) => ({ ...elem, data: elem.data.map((obj) => ({ ...obj })) }));
+  const copiedDrilldown = Object.values(drilldownSeries).map((elem) => ({ ...elem, data: elem.data.map((obj) => [...obj]) }));
+  const options = {
+    chart: {
+      type: 'column',
+    },
+    title: {
+      text: '우선순위 별 완료도',
+    },
+    xAxis: {
+      type: 'category',
+    },
+    yAxis: {
+      allowDecimals: false,
+      title: {
+        text: 'Tasks',
+      },
+      stackLabels: {
+        enabled: true,
+      },
+    },
+    plotOptions: {
+      series: {
+        stacking: 'normal',
+        borderWidth: 0,
+      },
+    },
+
+    series: copiedSeries,
+    drilldown: {
+      series: copiedDrilldown,
+    },
+  };
+
+  return (
+    <>
+      <HighchartsReact highcharts={Highcharts} options={options} />
+    </>
+  );
+};
+
+export default PriorityChart;

--- a/client/src/components/organisms/index.tsx
+++ b/client/src/components/organisms/index.tsx
@@ -21,3 +21,5 @@ export { default as HistoryHeader } from 'components/organisms/HistoryHeader';
 export { default as UserInProgressList } from 'components/organisms/UserInProgressList';
 export { default as BurnDownChart } from 'components/organisms/BurnDownChart';
 export { default as TaskRatioChart } from 'components/organisms/TaskRatioChart';
+export { default as DoneTaskChart } from 'components/organisms/DoneTaskChart';
+export { default as PriorityChart } from 'components/organisms/PriorityChart';

--- a/client/src/components/templates/ChartContainer/ChartHeader.tsx
+++ b/client/src/components/templates/ChartContainer/ChartHeader.tsx
@@ -18,12 +18,6 @@ const ChartHeader: React.FC = () => {
         </Title>
         {selectedChart === 'burndown' ? <StyledTitleUnderline /> : null}
       </StyledTitleWrapper>
-      <StyledTitleWrapper onClick={handleOnClickChartTitle} data-type={'velocity'}>
-        <Title color={'black'} cursor={'pointer'}>
-          {'속도'}
-        </Title>
-        {selectedChart === 'velocity' ? <StyledTitleUnderline /> : null}
-      </StyledTitleWrapper>
       <StyledTitleWrapper onClick={handleOnClickChartTitle} data-type={'task-ratio'}>
         <Title color={'black'} cursor={'pointer'}>
           {'담당한 일 비율'}
@@ -36,11 +30,11 @@ const ChartHeader: React.FC = () => {
         </Title>
         {selectedChart === 'priority' ? <StyledTitleUnderline /> : null}
       </StyledTitleWrapper>
-      <StyledTitleWrapper onClick={handleOnClickChartTitle} data-type={'finished-task'}>
+      <StyledTitleWrapper onClick={handleOnClickChartTitle} data-type={'task-done'}>
         <Title color={'black'} cursor={'pointer'}>
-          {'완료한 태스크 수'}
+          {'태스크 완료도'}
         </Title>
-        {selectedChart === 'finished-task' ? <StyledTitleUnderline /> : null}
+        {selectedChart === 'task-done' ? <StyledTitleUnderline /> : null}
       </StyledTitleWrapper>
     </StyledChartHeader>
   );

--- a/client/src/components/templates/ChartContainer/index.tsx
+++ b/client/src/components/templates/ChartContainer/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BurnDownChart, TaskRatioChart } from 'components/organisms';
+import { BurnDownChart, DoneTaskChart, PriorityChart, TaskRatioChart } from 'components/organisms';
 import { StyledChartBackground, StyledChartContainer } from './style';
 import ChartHeader from './ChartHeader';
 import { useRecoilValue } from 'recoil';
@@ -7,12 +7,23 @@ import { selectedChartState } from 'recoil/chart';
 
 const ChartContainer: React.FC = () => {
   const selectedChart = useRecoilValue(selectedChartState);
+  const ChartComponent = (chartName: string) => {
+    switch (chartName) {
+      case 'task-ratio':
+        return <TaskRatioChart />;
+      case 'priority':
+        return <PriorityChart />;
+      case 'task-done':
+        return <DoneTaskChart />;
+      case 'burndown':
+      default:
+        return <BurnDownChart />;
+    }
+  };
   return (
     <StyledChartContainer>
       <ChartHeader />
-      <StyledChartBackground>
-        {selectedChart === 'burndown' ? <BurnDownChart /> : selectedChart === 'task-ratio' ? <TaskRatioChart /> : null}
-      </StyledChartBackground>
+      <StyledChartBackground>{ChartComponent(selectedChart)}</StyledChartBackground>
     </StyledChartContainer>
   );
 };

--- a/client/src/hooks/useHistoryEmitter/index.ts
+++ b/client/src/hooks/useHistoryEmitter/index.ts
@@ -28,23 +28,25 @@ export interface INonHistoryEmitterProps {
 const useHistoryEmitter = () => {
   const { showError } = useToast();
 
-  const historyEmitter = ({ type, payload }: IHistoryEmitterProps) => {
+  const isSocketConnected = () => {
     if (!window.socket) {
       showError(new Error('서버와의 연결이 불안정합니다'));
-      return;
+      return false;
     }
+    return true;
+  };
+
+  const historyEmitter = ({ type, payload }: IHistoryEmitterProps) => {
+    if (!isSocketConnected()) return;
     payload = fillPayload(payload);
     console.log(type, payload);
-    window.socket.emit('history-event', type, JSON.stringify(payload));
+    window.socket!.emit('history-event', type, JSON.stringify(payload));
   };
 
   const nonHistoryEmitter = ({ type, payload }: INonHistoryEmitterProps) => {
-    if (!window.socket) {
-      showError(new Error('서버와의 연결이 불안정합니다'));
-      return;
-    }
+    if (!isSocketConnected()) return;
     console.log(type, payload);
-    window.socket.emit('non-history-event', type, JSON.stringify(payload));
+    window.socket!.emit('non-history-event', type, JSON.stringify(payload));
   };
 
   //* history-event
@@ -68,6 +70,10 @@ const useHistoryEmitter = () => {
   const addSprint = ({ name, startDate, endDate }: TAddSprint) =>
     nonHistoryEmitter({ type: 'ADD_SPRINT', payload: { name, startDate, endDate } });
   const deleteSprint = ({ sprintId }: TDeleteSprint) => nonHistoryEmitter({ type: 'DELETE_SPRINT', payload: { sprintId } });
+  const focusNode = (nodeId: number | null) => {
+    if (!isSocketConnected()) return;
+    window.socket!.emit('user-focus', nodeId);
+  };
 
   return {
     addNode,
@@ -79,6 +85,7 @@ const useHistoryEmitter = () => {
     deleteLabel,
     addSprint,
     deleteSprint,
+    focusNode,
   };
 };
 

--- a/client/src/hooks/useSocketDisconnect/index.ts
+++ b/client/src/hooks/useSocketDisconnect/index.ts
@@ -6,6 +6,7 @@ const useSocketDisconnect = () => {
   const [{ projectId }, setSocket] = useRecoilState(socketState);
   useEffect(() => {
     if (projectId) {
+      console.log('socket leave');
       window.socket!.emit('leave', projectId);
       window.socket = null;
       setSocket({ projectId: null });

--- a/client/src/hooks/useSocketSetup/index.ts
+++ b/client/src/hooks/useSocketSetup/index.ts
@@ -17,6 +17,7 @@ interface IInitProps {
 }
 
 const initSocket = ({ projectId, setSocket, historyReceiver, nonHistoryEventReceiver, userReceiver }: IInitProps) => {
+  console.log('socket connected');
   window.socket = io(process.env.REACT_APP_SERVER!, {
     query: {
       projectId,
@@ -62,11 +63,12 @@ const useSocketSetup = () => {
       const isNewProject = projectId !== newProjectId;
       if (!isNewProject) return;
       if (projectId) {
+        console.log('socket leave');
         window.socket!.emit('leave', projectId);
         window.socket = null;
       }
       initSocket({ projectId: newProjectId, setSocket, historyReceiver, nonHistoryEventReceiver, userReceiver });
     })();
-  }, [newProjectId, projectId, setSocket, historyReceiver, userReceiver]);
+  }, [newProjectId, projectId, historyReceiver, userReceiver]);
 };
 export default useSocketSetup;

--- a/client/src/hooks/useSocketSetup/index.ts
+++ b/client/src/hooks/useSocketSetup/index.ts
@@ -1,12 +1,13 @@
 import useProjectId from 'hooks/useRoomId';
 import useHistoryReceiver, { IHistoryReceiver } from 'hooks/useHistoryReceiver';
 import { useEffect } from 'react';
-import { SetterOrUpdater, useRecoilState } from 'recoil';
+import { SetterOrUpdater, useRecoilState, useSetRecoilState } from 'recoil';
 import { ISocket, socketState } from 'recoil/socket';
 import io from 'socket.io-client';
 import useUserReceiver, { IUserReceiver } from 'hooks/useUserReceiver';
 import { parseHistoryEvent, parseNonHistoryEvent } from 'utils/parser';
 import { INonHistoryEventData } from 'types/event';
+import { userFocusNodeState } from 'recoil/project';
 
 interface IInitProps {
   projectId: string;
@@ -14,9 +15,10 @@ interface IInitProps {
   historyReceiver: IHistoryReceiver;
   nonHistoryEventReceiver: (eventData: INonHistoryEventData) => void;
   userReceiver: IUserReceiver;
+  setUserFocusNode: SetterOrUpdater<Map<string, number>>;
 }
 
-const initSocket = ({ projectId, setSocket, historyReceiver, nonHistoryEventReceiver, userReceiver }: IInitProps) => {
+const initSocket = ({ projectId, setSocket, historyReceiver, nonHistoryEventReceiver, userReceiver, setUserFocusNode }: IInitProps) => {
   console.log('socket connected');
   window.socket = io(process.env.REACT_APP_SERVER!, {
     query: {
@@ -40,6 +42,11 @@ const initSocket = ({ projectId, setSocket, historyReceiver, nonHistoryEventRece
   });
   socket.on('left', (userId: string) => {
     userReceiver({ data: userId, type: 'LEFT' });
+    setUserFocusNode((prev) => {
+      const next = new Map(prev);
+      next.delete(userId);
+      return next;
+    });
   });
   socket.on('history-event', (data, dbData) => {
     const eventData = parseHistoryEvent(data, dbData);
@@ -49,12 +56,21 @@ const initSocket = ({ projectId, setSocket, historyReceiver, nonHistoryEventRece
     const eventData = parseNonHistoryEvent(data, dbData);
     nonHistoryEventReceiver(eventData);
   });
+  socket.on('user-focus', (userId, nodeId) => {
+    setUserFocusNode((prev) => {
+      const next = new Map(prev);
+      if (nodeId) next.set(userId, nodeId);
+      else next.delete(userId);
+      return next;
+    });
+  });
   setSocket({ projectId });
 };
 
 const useSocketSetup = () => {
   const newProjectId = useProjectId();
   const [{ projectId }, setSocket] = useRecoilState(socketState);
+  const setUserFocusNode = useSetRecoilState(userFocusNodeState);
   const { historyReceiver, nonHistoryEventReceiver } = useHistoryReceiver();
   const userReceiver = useUserReceiver();
 
@@ -67,7 +83,7 @@ const useSocketSetup = () => {
         window.socket!.emit('leave', projectId);
         window.socket = null;
       }
-      initSocket({ projectId: newProjectId, setSocket, historyReceiver, nonHistoryEventReceiver, userReceiver });
+      initSocket({ projectId: newProjectId, setSocket, historyReceiver, nonHistoryEventReceiver, userReceiver, setUserFocusNode });
     })();
   }, [newProjectId, projectId, historyReceiver, userReceiver]);
 };

--- a/client/src/pages/Mindmap/index.tsx
+++ b/client/src/pages/Mindmap/index.tsx
@@ -1,11 +1,18 @@
 import { MindmapTemplate } from 'components/templates';
 import CommonLayout from 'components/templates/CommonLayout';
+import useHistoryEmitter from 'hooks/useHistoryEmitter';
 import { useCallback, useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 import { selectedNodeIdState } from 'recoil/node';
 
 const MindmapPage = () => {
   const setSelectedNodeId = useSetRecoilState(selectedNodeIdState);
+  const { focusNode } = useHistoryEmitter();
+
+  const selectNode = (nodeId: number | null) => {
+    setSelectedNodeId(nodeId);
+    focusNode(nodeId);
+  };
 
   const HandleNodeClick = useCallback(
     (event: MouseEvent) => {
@@ -13,12 +20,12 @@ const MindmapPage = () => {
       const eventTarget = event.target as HTMLElement;
       const eventParent = eventTarget?.parentNode as HTMLElement;
 
-      if (eventTarget.classList.contains('child-container') || eventTarget.tagName === 'svg') return setSelectedNodeId(null);
-      if (eventParent?.classList.contains('node')) return setSelectedNodeId(Number(eventParent.id));
+      if (eventTarget.classList.contains('child-container') || eventTarget.tagName === 'svg') return selectNode(null);
+      if (eventParent?.classList.contains('node')) return selectNode(Number(eventParent.id));
       if (!eventTarget.classList.contains('mindmap-area')) return;
-      if (eventTarget.classList.contains('node')) return setSelectedNodeId(Number(eventTarget.id));
+      if (eventTarget.classList.contains('node')) return selectNode(Number(eventTarget.id));
 
-      setSelectedNodeId(null);
+      selectNode(null);
     },
     [setSelectedNodeId]
   );

--- a/client/src/recoil/chart/index.ts
+++ b/client/src/recoil/chart/index.ts
@@ -1,6 +1,80 @@
-import { atom } from 'recoil';
+import { atom , selector } from 'recoil';
+
+import { mindmapNodesState } from 'recoil/mindmap';
+import { sprintListState, userListState } from 'recoil/project';
 
 export const selectedChartState = atom<string>({
   key: 'selectedChart',
   default: 'burndown',
 });
+
+interface IDoneTaskChartData {
+  name: string;
+  color: string;
+  data: Array<number>;
+  stack: string;
+  total: number;
+  legendIndex: number;
+}
+
+interface IDoneTaskChartState {
+  categories: Array<string>;
+  series: { [index: string]: IDoneTaskChartData };
+  dictSprintname: { [index: string]: number };
+  dictUsername: { [index: string]: string };
+}
+
+type TDoneTaskSeriesObj = { [index: string]: IDoneTaskChartData };
+const doneTaskChartState = selector<IDoneTaskChartState>({
+  key: 'doneTaskChartState',
+  get: ({ get }) => {
+    const sprintList = get(sprintListState);
+    const userList = get(userListState);
+    const nodes = get(mindmapNodesState);
+
+    const sprintLength = Object.values(sprintList).length;
+    const sprintNames = Object.values(sprintList).map((sprint) => sprint.name);
+    const series: TDoneTaskSeriesObj = {
+      entire: {
+        name: '주차 별 할당',
+        color: '#bbbbbb',
+        data: Array(sprintLength).fill(0),
+        stack: 'Entire',
+        total: 0,
+        legendIndex: 0,
+      },
+    };
+    const categories: Array<string> = [];
+    const dictSprintname: { [index: string]: number } = {};
+    Object.values(sprintList).forEach((sprint) => {
+      categories.push(sprint.name + '<br/>' + sprint.startDate + ' ~ ' + sprint.endDate.split('-').pop());
+      dictSprintname[sprint.name] = sprint.id;
+    });
+
+    const dictUsername: { [index: string]: string } = {};
+    Object.values(userList).forEach(({ id, name, color }, i) => {
+      series[id] = { name: name, color: '#' + color, data: Array(sprintLength).fill(0), stack: 'Done', total: 0, legendIndex: i + 1 };
+      dictUsername[name] = id;
+    });
+
+    nodes.forEach(({ status, assigneeId, sprintId }) => {
+      if (!sprintId) return;
+      const sprintIdx = sprintNames.indexOf(sprintList[sprintId].name);
+      series.entire.data[sprintIdx]++;
+      series.entire.total++;
+      if (assigneeId && status === 'Done') {
+        series[assigneeId].data[sprintIdx]++;
+        series[assigneeId].total++;
+      }
+    });
+
+    return {
+      categories: categories,
+      series: series,
+      dictSprintname: dictSprintname,
+      dictUsername: dictUsername,
+    };
+  },
+});
+
+export { doneTaskChartState };

--- a/client/src/recoil/chart/index.ts
+++ b/client/src/recoil/chart/index.ts
@@ -2,6 +2,7 @@ import { atom , selector } from 'recoil';
 
 import { mindmapNodesState } from 'recoil/mindmap';
 import { sprintListState, userListState } from 'recoil/project';
+import { IUser } from 'types/user';
 
 export const selectedChartState = atom<string>({
   key: 'selectedChart',
@@ -77,4 +78,97 @@ const doneTaskChartState = selector<IDoneTaskChartState>({
   },
 });
 
-export { doneTaskChartState };
+interface IPriorityChartData {
+  name: string;
+  data: Array<IPriorityChartSeriesData>;
+}
+
+interface IPriorityChartSeriesData {
+  name: string;
+  y: number;
+  drilldown: string;
+}
+
+type TDrilldownData = (string | number)[];
+interface IPriorityChartDrilldownData {
+  id: string;
+  name: string;
+  data: Array<TDrilldownData>;
+}
+
+interface IPriorityChartState {
+  series: TPrioritySeriesObj;
+  drilldownSeries: TPriorityDrilldownObj;
+}
+type TPrioritySeriesObj = { [index: string]: IPriorityChartData };
+type TPriorityDrilldownObj = { [index: string]: IPriorityChartDrilldownData };
+const getPriorityIndex = (priority: string) => {
+  return priority === '높음' ? 0 : priority === '보통' ? 1 : 2;
+};
+
+const initSeries = (sprintName: string) => {
+  return {
+    name: sprintName,
+    data: [initSeriesData(sprintName, '높음'), initSeriesData(sprintName, '보통'), initSeriesData(sprintName, '낮음')],
+  };
+};
+
+const initSeriesData = (sprintName: string, priority: string) => {
+  return {
+    name: priority,
+    y: 0,
+    drilldown: sprintName + '-' + priority,
+  };
+};
+
+const initDrilldownSeries = (drilldownSeries: TPriorityDrilldownObj, sprintName: string, userList: Record<string, IUser>) => {
+  ['높음', '낮음', '보통'].forEach((priority) => {
+    drilldownSeries[sprintName + priority] = initDrilldownData(sprintName, priority, userList);
+  });
+};
+
+const initDrilldownData = (sprintName: string, priority: string, userList: Record<string, IUser>) => {
+  return {
+    id: sprintName + '-' + priority,
+    name: sprintName + ', 우선순위: ' + priority,
+    data: Object.values(userList).map(({ name }) => [name, 0]),
+  } as IPriorityChartDrilldownData;
+};
+
+const priorityChartState = selector<IPriorityChartState>({
+  key: 'priorityChartState',
+  get: ({ get }) => {
+    const sprintList = get(sprintListState);
+    const userList = get(userListState);
+    const nodes = get(mindmapNodesState);
+    const series: TPrioritySeriesObj = { '남은 Task': initSeries('남은 Task') };
+    const drilldownSeries: TPriorityDrilldownObj = {};
+    initDrilldownSeries(drilldownSeries, '남은 Task', userList);
+
+    nodes.forEach(({ sprintId, priority, status, assigneeId }) => {
+      if (!sprintId) return;
+      const sprintName = sprintList[sprintId].name;
+      if (!series[sprintName]) {
+        series[sprintName] = initSeries(sprintName);
+        initDrilldownSeries(drilldownSeries, sprintName, userList);
+      }
+      if (!priority) return;
+      const updateSeries = (name: string) => {
+        series[name].data[getPriorityIndex(priority)].y++;
+        if (assigneeId) {
+          const data = drilldownSeries[name + priority]?.data.find((v) => v[0] === userList[assigneeId].name) as TDrilldownData;
+          (data[1] as number)++;
+        }
+      };
+      if (status === 'Done') updateSeries(sprintName);
+      else updateSeries('남은 Task');
+    });
+
+    return {
+      series: series,
+      drilldownSeries: drilldownSeries,
+    };
+  },
+});
+
+export { doneTaskChartState, priorityChartState };

--- a/client/src/recoil/project/index.ts
+++ b/client/src/recoil/project/index.ts
@@ -51,6 +51,11 @@ const userMouseOverState = atom<string>({
   default: '',
 });
 
+const userFocusNodeState = atom<Map<string, number>>({
+  key: 'userFocusNode',
+  default: new Map(),
+});
+
 const filteredTaskState = selector<Record<number, IMindNode>>({
   key: 'filteredTask',
   get: ({ get }) => {
@@ -217,6 +222,7 @@ export {
   sprintFilterState,
   labelFilterState,
   userMouseOverState,
+  userFocusNodeState,
   filteredTaskState,
   filteredTaskTimeState,
   filteredUserInProgressTaskState,

--- a/server/src/utils/socket.ts
+++ b/server/src/utils/socket.ts
@@ -38,6 +38,7 @@ const socketIO = (server, origin) => {
 
   io.on('connection', async (socket: ISocket) => {
     const { id } = socket.decoded;
+    console.log(id, 'connected');
     const projectId = socket.handshake.query.projectId as string;
 
     const handleNewEvent = async (data: Record<number, object>) => {
@@ -74,6 +75,7 @@ const socketIO = (server, origin) => {
 
     socket.on('leave', (targetProjectId) => {
       socket.leave(targetProjectId);
+      console.log(id, 'leave');
       socket.disconnect();
     });
 

--- a/server/src/utils/socket.ts
+++ b/server/src/utils/socket.ts
@@ -91,6 +91,10 @@ const socketIO = (server, origin) => {
       const dbData = await convertEvent(eventData);
       io.in(projectId).emit('non-history-event', eventData, dbData);
     });
+    socket.on('user-focus', (nodeId) => {
+      console.log(id, nodeId);
+      io.in(projectId).emit('user-focus', id, nodeId);
+    });
   });
 };
 export default socketIO;


### PR DESCRIPTION
## 📑 제목
Task 완료도 및 우선순위 차트 구현 & 사용자 노드 포커싱 소켓 이벤트 구현
## 📎 관련 이슈
- #132 
- #134 
- #135 
- #137 
## ✔️ 셀프 체크리스트
- [X] 차트에서 정보를 쉽게 파악할 수 있다
- [X] 차트에서 편리한 상호작용을 제공한다
- [X] 사용자 간 노드 포커싱 상태를 공유할 수 있다
## 💬 작업 내용
- Task 완료도 차트 구현
- 완료도 차트 클릭 시 필터링 되어 백로그로 이동되도록 구현
- 우선순위 차트 구현
- 사용자 노드 포커싱 소켓 이벤트 구현
## 🚧 PR 특이 사항
- 속도 차트를 태스크 완료도 차트에 포함시켰다.
- 추가 차트에 대해 고민하다가 지금 차트 상태도 괜찮다고 생각되어 구현하지 않기로 하였음. 피드백 바람
- 차트 그릴 때 필요 정보가 너무 많고 option 양식이 정해져 있어서 힘들었음 코드가 긴데 더 줄일 수 있을지 의문 
## 🕰 실제 소요 시간
12hr