### PR TITLE
1~10일 캘린더 태스크 안그려지는 버그

### DIFF
--- a/client/src/components/organisms/NodeDetailWrapper/index.tsx
+++ b/client/src/components/organisms/NodeDetailWrapper/index.tsx
@@ -206,17 +206,6 @@ export const NodeDetailWrapper = () => {
                 margin='0.1rem 0'
               />
             </Label>
-            <Label label='진행 상태' htmlFor='status' labelStyle='small' ratio={0.5}>
-              <Dropdown
-                id='status'
-                key={selectedNode.status}
-                items={statusDropdownItem}
-                placeholder={selectedNode.status}
-                onValueChange={handleChangeNodeDetail('status')}
-                dropdownStyle='small'
-                margin='0.1rem 0'
-              />
-            </Label>
           </PopupItemLayout>
           <PopupItemLayout title={'라벨'}>
             <LabelList labelIds={JSON.parse(selectedNode.labelIds ?? '[]')} onChange={requestLabelChange} />

--- a/client/src/components/organisms/ScheduleCalendar/LayerScheduleMonth.tsx
+++ b/client/src/components/organisms/ScheduleCalendar/LayerScheduleMonth.tsx
@@ -3,7 +3,7 @@ import LayerScheduleDay from './LayerScheduleDay';
 import { useRecoilValue } from 'recoil';
 import { filteredTaskState } from 'recoil/project';
 import { IMindNode } from 'types/mindmap';
-import { parseISODate } from 'utils/date';
+import { makeISODate, parseISODate } from 'utils/date';
 
 interface IProps {
   currentDateISO: string;
@@ -47,7 +47,7 @@ const LayerScheduleMonth: React.FC<IProps> = ({ currentDateISO, setHoveredNode }
           <LayerScheduleDay
             key={idx}
             dayDate={{ year, month, date: idx + 1 }}
-            tasks={taskMapToDueDate[`${year}-${month}-${idx + 1}`]}
+            tasks={taskMapToDueDate[makeISODate({ year, month, date: idx + 1 })]}
             setHoveredNode={setHoveredNode}
           />
         ))}


### PR DESCRIPTION
## 📑 제목
1~10일 캘린더 안그려지는 버그

## 📎 관련 이슈
- #175

## ✔️ 셀프 체크리스트
1~10일에도 태스크가 그려진다.

## 💬 작업 내용
파싱 문제 해결

![녹화_2021_11_25_21_57_29_803](https://user-images.githubusercontent.com/73219421/143446147-cede16e9-1d24-43bd-aeec-076efdfbf108.gif)

## 🚧 PR 특이 사항
시작날짜 완료날짜 설정을 위해 상세정보창에서 변경 제거

## 🕰 실제 소요 시간
0.5h
