### PR TITLE
히스토리 포커싱

### DIFF
--- a/client/src/components/molecules/HistoryWindow/index.tsx
+++ b/client/src/components/molecules/HistoryWindow/index.tsx
@@ -15,6 +15,7 @@ interface IProps {
 
 const HistoryWindow: React.FC<IProps> = ({ onClick }) => {
   const dragRef = useRef<HTMLDivElement | null>(null);
+  const refs = useRef<HTMLDivElement[]>([]);
   const { getMoreHistoryData } = useNewHistoryData();
   const historyDataList = useRecoilValue(historyDataListState);
   const userList = useRecoilValue(userListState);
@@ -30,6 +31,14 @@ const HistoryWindow: React.FC<IProps> = ({ onClick }) => {
     container.scrollBy({ left: container.scrollWidth - container.clientWidth / 2 });
   }, [historyDataList]);
 
+  const addToRefs = (el: HTMLDivElement) => refs.current.push(el);
+
+  useEffect(() => {
+    if (refs.current.length === 0) return;
+    const target = refs.current.at(currentReverseIdx);
+    target!.scrollIntoView({ inline: 'center', behavior: 'smooth' });
+  }, [currentReverseIdx]);
+
   return (
     <Wrapper ref={dragRef} className='background'>
       <Before exist={historyDataList.length ? true : false} />
@@ -37,6 +46,7 @@ const HistoryWindow: React.FC<IProps> = ({ onClick }) => {
       {historyDataList.length && userList
         ? historyDataList.map((historyData, idx) => (
             <IconWrapper
+              ref={addToRefs}
               key={historyData.historyId}
               onClick={onClick(idx - historyDataList.length)}
               isSelected={isSelected(idx - historyDataList.length)}

--- a/client/src/components/molecules/Tree/index.tsx
+++ b/client/src/components/molecules/Tree/index.tsx
@@ -153,6 +153,12 @@ const Tree: React.FC<ITreeProps> = ({ nodeId, mindmapData, parentCoord, parentId
     removeTempNode();
   };
 
+  useEffect(() => {
+    if (isHistorySelected) {
+      nodeRef.current?.scrollIntoView({ block: 'center', inline: 'center' });
+    }
+  }, [isHistorySelected]);
+
   return (
     <NodeContainer id={nodeId + 'container'} ref={containerRef} isRoot={isRoot} className='node-container mindmap-area'>
       {nodeId === TEMP_NODE_ID ? (


### PR DESCRIPTION
## 📑 제목
히스토리 포커싱
## 📎 관련 이슈

## ✔️ 셀프 체크리스트
- [x] 변경된 히스토리 마인드맵 노드가 가운데에 위치하도록 포커싱
- [x] 선택된 히스토리 아이콘이 가운데에 위치하도록 포커싱
## 💬 작업 내용
- 마인드맵 노드에 isHistorySelected일 때 scrollIntoView로 포커싱
- currentReverseSelectedId를 통해 scrollIntoView로 포커싱
## 🚧 PR 특이 사항
- map관련 ref 적용
## 🕰 실제 소요 시간
- 0.5h