### PR TITLE
배경 드래그로 스크롤 범위 확장

### DIFF
--- a/client/src/hooks/useDragBackground/index.tsx
+++ b/client/src/hooks/useDragBackground/index.tsx
@@ -16,6 +16,11 @@ const useDragBackground = (dragTarget: HTMLDivElement | null | (Window & typeof 
       if ((target as HTMLElement).tagName !== 'DIV') return;
       if (!(target as HTMLElement).className.includes('background')) return;
 
+      const isTargetHasClassName = (className: string) => (target as HTMLElement).className.includes(className);
+
+      if (!isTargetHasClassName('background') && !isTargetHasClassName('child-container') && !isTargetHasClassName('node-container'))
+        return;
+
       draggable.current = true;
       lastCoord.current = { screenX, screenY };
     },

--- a/client/src/hooks/useDragBackground/index.tsx
+++ b/client/src/hooks/useDragBackground/index.tsx
@@ -14,13 +14,12 @@ const useDragBackground = (dragTarget: HTMLDivElement | null | (Window & typeof 
     ({ screenX, screenY, target }: MouseEvent) => {
       if (!target) return;
       if ((target as HTMLElement).tagName !== 'DIV') return;
-      if (!(target as HTMLElement).className.includes('background')) return;
 
       const isTargetHasClassName = (className: string) => (target as HTMLElement).className.includes(className);
 
       if (!isTargetHasClassName('background') && !isTargetHasClassName('child-container') && !isTargetHasClassName('node-container'))
         return;
-
+      console.log(1);
       draggable.current = true;
       lastCoord.current = { screenX, screenY };
     },


### PR DESCRIPTION
## 📑 제목
배경 드래그로 스크롤 범위 확장
## 📎 관련 이슈
Hot Fix
## ✔️ 셀프 체크리스트
- [x] 노드 주변 컨테이너를 눌러서도 드래그 가능
## 💬 작업 내용
- 노드 주변 컨테이너도 draggable 하도록 포함 (코드 복구)
## 🚧 PR 특이 사항
- 머지 중 이전으로 돌아가서 다시 원상복구
## 🕰 실제 소요 시간
- 0.5h