### PR TITLE
 노드 필터링 테스트 + 도커 redis 볼륨 이슈 해결

### DIFF
--- a/client/src/components/organisms/FilterPopup/index.test.tsx
+++ b/client/src/components/organisms/FilterPopup/index.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render } from '@testing-library/react';
+import { ThemeProvider } from '@emotion/react';
+import { RecoilRoot } from 'recoil';
+import FilterPopup from './index';
+import { labelListState, sprintFilterState, sprintListState, userListState } from 'recoil/project';
+import { common } from 'styles';
+
+describe('필터링 팝업에서', () => {
+  const renderFilterPopup = () => {
+    return render(
+      <ThemeProvider theme={common}>
+        <RecoilRoot
+          initializeState={(snap) => {
+            snap.set(sprintListState, {
+              1: { id: 1, name: '스프린트1', color: '2E25EB', startDate: '2021-10-13', endDate: '2021-11-12' },
+            });
+            snap.set(userListState, {
+              aa: { id: 'aa', name: '1번손님', color: '6ED5EB', icon: 'frog' },
+            });
+            snap.set(labelListState, {
+              1: { id: 1, name: '라벨1', color: '4A6CC3' },
+            });
+            snap.set(sprintFilterState, 1);
+          }}
+        >
+          <FilterPopup onClose={() => {}} />
+        </RecoilRoot>
+      </ThemeProvider>
+    );
+  };
+
+  it('초기에는 스프린트 리스트를 보여준다.', () => {
+    const { queryByText } = renderFilterPopup();
+    expect(queryByText('스프린트1')).toBeInTheDocument();
+  });
+
+  it('다른 메뉴를 클릭 시 스프린트를 표기하지 않는다.', () => {
+    const { container, queryByText } = renderFilterPopup();
+    fireEvent.click(container.querySelectorAll('span')[1]);
+    expect(queryByText('스프린트0')).toBeNull();
+  });
+
+  it('담당자 메뉴 클릭 시 유저 리스트 표기한다.', () => {
+    const { container, queryByText } = renderFilterPopup();
+    fireEvent.click(container.querySelectorAll('span')[1]);
+    expect(queryByText('1번손님')).toBeInTheDocument();
+  });
+
+  it('라벨 메뉴 클릭 시, 라벨 리스트를 표기한다.', () => {
+    const { container, queryByText } = renderFilterPopup();
+    fireEvent.click(container.querySelectorAll('span')[2]);
+    expect(queryByText('라벨1')).toBeInTheDocument();
+  });
+
+  it('적용된 필터를 표시한다.', () => {
+    const { container } = renderFilterPopup();
+    expect(container.querySelector('p')).toHaveTextContent('필터링: 스프린트1');
+  });
+});

--- a/client/src/recoil/project/index.test.ts
+++ b/client/src/recoil/project/index.test.ts
@@ -1,0 +1,74 @@
+import { snapshot_UNSTABLE } from 'recoil';
+import { mindmapState } from 'recoil/mindmap';
+import { assigneeFilterState, filteredTaskState, labelFilterState, sprintFilterState } from '.';
+
+describe('FilteredTask selector는', () => {
+  const dummyNode = (nodeId: number, assigneeId: string, sprintId: number, labelIds: string, level: string) => ({
+    nodeId,
+    assigneeId,
+    sprintId,
+    labelIds,
+    level,
+  });
+  const initialMindMap = new Map();
+  initialMindMap.set(0, dummyNode(1, '담당자1', 1, '[1]', 'TASK'));
+  initialMindMap.set(1, dummyNode(2, '담당자2', 2, '[2]', 'TASK'));
+  initialMindMap.set(2, dummyNode(3, '담당자3', 3, '[3]', 'TASK'));
+  initialMindMap.set(3, dummyNode(4, '담당자2', 2, '[1,3]', 'TASK'));
+  initialMindMap.set(4, dummyNode(5, '담당자1', 2, '[1,2,3]', 'STORY'));
+
+  it('테스크만을 반환한다.', () => {
+    const testSnapshot = snapshot_UNSTABLE(({ set }) => set(mindmapState, { rootId: 1, mindNodes: initialMindMap }));
+    const filteredTask = testSnapshot.getLoadable(filteredTaskState).valueOrThrow();
+    expect(Object.values(filteredTask)).toHaveLength(4);
+  });
+
+  it('스프린트 필터를 적용할 수 있다.', () => {
+    const testSnapshot = snapshot_UNSTABLE(({ set }) => {
+      set(mindmapState, { rootId: 1, mindNodes: initialMindMap });
+      set(sprintFilterState, 1);
+    });
+    const filteredTask = testSnapshot.getLoadable(filteredTaskState).valueOrThrow();
+    expect(Object.values(filteredTask)).toHaveLength(1);
+  });
+
+  it('라벨 필터를 적용할 수 있다.', () => {
+    const testSnapshot = snapshot_UNSTABLE(({ set }) => {
+      set(mindmapState, { rootId: 1, mindNodes: initialMindMap });
+      set(labelFilterState, 3);
+    });
+    const filteredTask = testSnapshot.getLoadable(filteredTaskState).valueOrThrow();
+    expect(Object.values(filteredTask)).toHaveLength(2);
+  });
+
+  it('담당자 필터를 적용할 수 있다.', () => {
+    const testSnapshot = snapshot_UNSTABLE(({ set }) => {
+      set(mindmapState, { rootId: 1, mindNodes: initialMindMap });
+      set(assigneeFilterState, '담당자2');
+    });
+    const filteredTask = testSnapshot.getLoadable(filteredTaskState).valueOrThrow();
+    expect(Object.values(filteredTask)).toHaveLength(2);
+  });
+
+  it('복수의 필터를 적용할 수 있다.', () => {
+    const testSnapshot = snapshot_UNSTABLE(({ set }) => {
+      set(mindmapState, { rootId: 1, mindNodes: initialMindMap });
+      set(sprintFilterState, 2);
+      set(labelFilterState, 2);
+      set(assigneeFilterState, '담당자2');
+    });
+    const filteredTask = testSnapshot.getLoadable(filteredTaskState).valueOrThrow();
+    expect(Object.values(filteredTask)).toHaveLength(1);
+  });
+
+  it('필터의 결과가 비었을 때는 빈 배열을 반환한다.', () => {
+    const testSnapshot = snapshot_UNSTABLE(({ set }) => {
+      set(mindmapState, { rootId: 1, mindNodes: initialMindMap });
+      set(sprintFilterState, 2);
+      set(labelFilterState, 2);
+      set(assigneeFilterState, '담당자1');
+    });
+    const filteredTask = testSnapshot.getLoadable(filteredTaskState).valueOrThrow();
+    expect(Object.values(filteredTask)).toHaveLength(0);
+  });
+});

--- a/client/src/setupTests.ts
+++ b/client/src/setupTests.ts
@@ -1,0 +1,3 @@
+// learn more: https://stackoverflow.com/questions/56547215/react-testing-library-why-is-tobeinthedocument-not-a-function
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/extend-expect';

--- a/client/src/styles/global.ts
+++ b/client/src/styles/global.ts
@@ -1,7 +1,7 @@
 import emotionReset from 'emotion-reset';
 import { css } from '@emotion/react';
 
-const global = css`
+const globalStyle = css`
   ${emotionReset}
   *,
   *::after,
@@ -16,4 +16,4 @@ const global = css`
   }
 `;
 
-export default global;
+export default globalStyle;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,7 @@ services:
     image: redis
     volumes:
       - ./server/redis.conf:/usr/local/etc/redis/redis.conf
+      - /data/redis:/data
     ports:
       - 6379:6379
     command: redis-server /usr/local/etc/redis/redis.conf


### PR DESCRIPTION
## 📑 제목
 노드 필터링 테스트

## 📎 관련 이슈
- #194 
- #195 

## ✔️ 셀프 체크리스트
 스프린트 필터를 테스트한다.
 라벨 필터를 테스트 한다.
 작성자 필터를 테스트한다.
 태스크가 없을때, 여러 필터 적용시 케이스도 확인한다.

## 💬 작업 내용
도커 레디스 백업 저장 해결
필터링 팝업 컴포넌트 단위 테스트 코드 작성
필터링 태스크 셀렉터 단위 테스트 코드 작성

## 🚧 PR 특이 사항
바벨 인식을 위해 setting 추가했습니다.
도커 redis 백업 이슈 해결했는데, 서버에서 확인 필요합니다.

## 🕰 실제 소요 시간
5h
