### PR TITLE
히스토리 로그 버그, 프로젝트 카드 삭제 버튼 이슈 #208, #209

### DIFF
--- a/client/src/components/organisms/ProjectCard/index.tsx
+++ b/client/src/components/organisms/ProjectCard/index.tsx
@@ -3,6 +3,8 @@ import { IconButton } from 'components/molecules';
 import { IconImg, SmallText, Title } from 'components/atoms';
 import { StyledBottomContainer, StyledIconContainer, StyledLowerContainer, StyledProjectCard, StyledTextContainer } from './style';
 import { participants, share, thumbnail, trashcan } from 'img';
+import { useRecoilValue } from 'recoil';
+import { userState } from 'recoil/user';
 
 interface IProps {
   projectId: string;
@@ -15,10 +17,14 @@ interface IProps {
     color: string;
     icon: string;
     name: string;
+    id: string;
   };
 }
 
 const ProjectCard: React.FC<IProps> = ({ name, count, creator, onClickShareButton, onClickDeleteButton, onClickProjectCard }) => {
+  const user = useRecoilValue(userState);
+  const isCreator = creator.id === user?.id;
+
   return (
     <StyledProjectCard onClick={onClickProjectCard} color={creator.color}>
       <IconImg imgSrc={thumbnail} altText='썸네일' size={{ width: '100%', height: '60%' }} noPadding={true} noHover={true} />
@@ -40,7 +46,7 @@ const ProjectCard: React.FC<IProps> = ({ name, count, creator, onClickShareButto
           </StyledIconContainer>
           <StyledIconContainer>
             <IconButton onClick={onClickShareButton} imgSrc={share} altText='공유하기 버튼' />
-            <IconButton onClick={onClickDeleteButton} imgSrc={trashcan} altText='삭제하기 버튼' />
+            {isCreator && <IconButton onClick={onClickDeleteButton} imgSrc={trashcan} altText='삭제하기 버튼' />}
           </StyledIconContainer>
         </StyledLowerContainer>
       </StyledBottomContainer>

--- a/client/src/components/organisms/ProjectCard/index.tsx
+++ b/client/src/components/organisms/ProjectCard/index.tsx
@@ -26,7 +26,7 @@ const ProjectCard: React.FC<IProps> = ({ name, count, creator, onClickShareButto
   const isCreator = creator.id === user?.id;
 
   return (
-    <StyledProjectCard onClick={onClickProjectCard} color={creator.color}>
+    <StyledProjectCard onClick={onClickProjectCard}>
       <IconImg imgSrc={thumbnail} altText='썸네일' size={{ width: '100%', height: '60%' }} noPadding={true} noHover={true} />
       <StyledBottomContainer>
         <StyledTextContainer>

--- a/client/src/components/organisms/ProjectCard/index.tsx
+++ b/client/src/components/organisms/ProjectCard/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { IconButton } from 'components/molecules';
 import { IconImg, SmallText, Title } from 'components/atoms';
-import { StyledBottomContainer, StyledIconContainer, StyledLowerContainer, StyledProjectCard, StyledTextContainer } from './style';
+import { StyledBottomWrapper, StyledIconContainer, StyledLowerWrapper, StyledProjectCard, StyledTextContainer } from './style';
 import { participants, share, thumbnail, trashcan } from 'img';
 import { useRecoilValue } from 'recoil';
 import { userState } from 'recoil/user';
@@ -28,7 +28,7 @@ const ProjectCard: React.FC<IProps> = ({ name, count, creator, onClickShareButto
   return (
     <StyledProjectCard onClick={onClickProjectCard}>
       <IconImg imgSrc={thumbnail} altText='썸네일' size={{ width: '100%', height: '60%' }} noPadding={true} noHover={true} />
-      <StyledBottomContainer>
+      <StyledBottomWrapper>
         <StyledTextContainer>
           <Title titleStyle={'xlarge'} cursor={'pointer'}>
             {name}
@@ -37,7 +37,7 @@ const ProjectCard: React.FC<IProps> = ({ name, count, creator, onClickShareButto
             {'프로젝트 관리자: ' + creator.name}
           </SmallText>
         </StyledTextContainer>
-        <StyledLowerContainer>
+        <StyledLowerWrapper>
           <StyledIconContainer>
             <IconImg imgSrc={participants} altText='' noHover={true} />
             <Title titleStyle={'normal'} margin='4px 0 0 0' cursor={'pointer'}>
@@ -48,8 +48,8 @@ const ProjectCard: React.FC<IProps> = ({ name, count, creator, onClickShareButto
             <IconButton onClick={onClickShareButton} imgSrc={share} altText='공유하기 버튼' />
             {isCreator && <IconButton onClick={onClickDeleteButton} imgSrc={trashcan} altText='삭제하기 버튼' />}
           </StyledIconContainer>
-        </StyledLowerContainer>
-      </StyledBottomContainer>
+        </StyledLowerWrapper>
+      </StyledBottomWrapper>
     </StyledProjectCard>
   );
 };

--- a/client/src/components/organisms/ProjectCard/style.tsx
+++ b/client/src/components/organisms/ProjectCard/style.tsx
@@ -17,10 +17,15 @@ export const StyledProjectCard = styled.div`
   }
 `;
 
-export const StyledLowerContainer = styled.div`
+export const StyledLowerWrapper = styled.div`
   ${({ theme }) => theme.flex.row}
   width: 100%;
   justify-content: space-between;
+`;
+
+export const StyledRowCenterWrapper = styled.div`
+  ${({ theme }) => theme.flex.rowCenter};
+  align-items: center;
 `;
 
 export const StyledIconContainer = styled.div`
@@ -29,7 +34,7 @@ export const StyledIconContainer = styled.div`
   margin-top: ${({ theme }) => theme.margin.normal};
 `;
 
-export const StyledBottomContainer = styled.div`
+export const StyledBottomWrapper = styled.div`
   ${({ theme }) => theme.flex.columnCenter};
   overflow: hidden;
   padding: ${({ theme }) => theme.padding.normal};

--- a/client/src/components/organisms/ProjectCard/style.tsx
+++ b/client/src/components/organisms/ProjectCard/style.tsx
@@ -1,17 +1,13 @@
 import styled from '@emotion/styled';
 
-interface IStyledProps {
-  color: string;
-}
-
-export const StyledProjectCard = styled.div<IStyledProps>`
+export const StyledProjectCard = styled.div`
   ${({ theme }) => theme.flex.column}
   width: 320px;
   height: 300px;
   background: ${({ theme }) => theme.color.bgWhite};
   border: 1px solid ${({ theme }) => theme.color.gray3};
   border-radius: 5px;
-  filter: ${({ color }) => `drop-shadow(0px 3px 3px #${color})`};
+  filter: drop-shadow(0px 3px 3px rgba(0, 0, 0, 0.25));
   margin: 10px;
   overflow: hidden;
   justify-content: space-between;

--- a/client/src/components/templates/ProjectCardContainer/index.tsx
+++ b/client/src/components/templates/ProjectCardContainer/index.tsx
@@ -6,8 +6,6 @@ import { NewProjectModalWrapper } from 'components/templates';
 import useToast from 'hooks/useToast';
 import { API } from 'utils/api';
 import { useHistory } from 'react-router';
-import { useRecoilValue } from 'recoil';
-import { userState } from 'recoil/user';
 
 const StyledProjectCardContainer = styled.div`
   ${(props) => props.theme.flex.row}
@@ -24,16 +22,14 @@ interface IProps {
 const ProjectCardContainer: React.FC<IProps> = ({ projectList, setProjectList }) => {
   const { showMessage } = useToast();
   const history = useHistory();
-  const user = useRecoilValue(userState);
 
   const handleClickShareButton = (event: React.MouseEvent<HTMLButtonElement>, projectId: string) => {
     event.stopPropagation();
     navigator.clipboard.writeText(process.env.REACT_APP_CLIENT + 'mindmap:' + projectId);
     showMessage('마인드맵 링크가 클립보드에 복사되었습니다.');
   };
-  const handleClickTrashButton = (event: React.MouseEvent<HTMLButtonElement>, projectId: string, userId: string) => {
+  const handleClickTrashButton = (event: React.MouseEvent<HTMLButtonElement>, projectId: string) => {
     event.stopPropagation();
-    if (!user || user.id !== userId) return showMessage('프로젝트 관리자만 삭제할 수 있습니다.');
     setProjectList((list) => list.filter((p) => p.id !== projectId));
     API.project.delete(projectId);
   };
@@ -57,7 +53,7 @@ const ProjectCardContainer: React.FC<IProps> = ({ projectList, setProjectList })
             creator={creator}
             onClickProjectCard={() => handleClickProjectCard(id)}
             onClickShareButton={(event: React.MouseEvent<HTMLButtonElement>) => handleClickShareButton(event, id)}
-            onClickDeleteButton={(event: React.MouseEvent<HTMLButtonElement>) => handleClickTrashButton(event, id, creator.id)}
+            onClickDeleteButton={(event: React.MouseEvent<HTMLButtonElement>) => handleClickTrashButton(event, id)}
           />
         );
       })}

--- a/client/src/hooks/useLog/index.tsx
+++ b/client/src/hooks/useLog/index.tsx
@@ -42,7 +42,7 @@ export const useLog = () => {
   };
 
   const convertTaskInformation = ({ dataFrom, dataTo }: IConvertTaskInformationParams) => {
-    const changedTask = Object.keys(dataFrom!.changed)[0];
+    const changedTask = Object.keys(dataTo!.changed)[0];
     let [task, before, after]: [string, string, string] = ['', '', ''];
 
     switch (changedTask) {
@@ -51,10 +51,12 @@ export const useLog = () => {
         before = `${dataFrom!.changed[changedTask] ? userList[dataFrom!.changed[changedTask]!].name : '지정하지 않음'}`;
         after = `${dataTo!.changed[changedTask] ? userList[dataTo!.changed[changedTask]!].name : '지정하지 않음'}`;
         break;
-      case 'labels':
+      case 'labelIds':
         task = ' 라벨 : ';
-        before = `${dataFrom!.changed[changedTask]!.map((labelId) => labelList[labelId])}`;
-        after = `${dataTo!.changed[changedTask]!.map((labelId) => labelList[labelId])}`;
+        const fromLabels = JSON.parse(dataFrom!.changed[changedTask]!);
+        const toLabels = JSON.parse(dataTo!.changed[changedTask]!);
+        before = `${fromLabels.length ? fromLabels.map((labelId: number) => labelList[labelId].name) : '지정하지 않음'}`;
+        after = `${toLabels.length ? toLabels.map((labelId: number) => labelList[labelId].name) : '지정하지 않음'}`;
         break;
       case 'priority':
         task = ' 중요도 : ';


### PR DESCRIPTION
## 📑 제목
일부 상세정보 수정 시 히스토리 로그 변경 안되는 버그 수정
## 📎 관련 이슈
- #208
- #209 
## ✔️ 셀프 체크리스트
- [x] 일부 상세정보 수정 시 히스토리 버그 변경 안되는 버그 수정
- [x] 프로젝트 관리자에게만 삭제 버튼 표시
## 💬 작업 내용
- 프로젝트 관리자에게만 삭제 버튼 표시
- 프로젝트 카드 그림자 색 제거
- 히스토리 로그 버그 수정
## 🚧 PR 특이 사항
- 라벨 수정 시 변경 전과 후의 데이터가 같게 전달된다. 수정 필요.
## 🕰 실제 소요 시간
2h