### PR TITLE
라벨 로그 이슈 + 뒤로가기 인증 이슈 해결

### DIFF
--- a/client/src/components/molecules/Dropdown/style.ts
+++ b/client/src/components/molecules/Dropdown/style.ts
@@ -40,12 +40,18 @@ export const DropdownList = styled.ul<IStyleProps>`
   width: 100%;
   background-color: ${({ theme }) => theme.color.gray4};
   margin-top: 0.2 rem;
+  max-height: 8rem;
+  overflow-y: auto;
+  ${({ theme }) => theme.customScrollbar.primary1}
   z-index: 1;
 
   li {
     ${({ dropdownStyle }) => styleOptions[dropdownStyle]}
     width: 100%;
     margin: 0.2rem 0;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
     &:hover {
       color: white;
       background-color: ${({ theme }) => theme.color.primary1};

--- a/client/src/components/organisms/Popups/NodeDetailPopup/index.tsx
+++ b/client/src/components/organisms/Popups/NodeDetailPopup/index.tsx
@@ -106,12 +106,13 @@ export const NodeDetailWrapper = () => {
     }
   };
 
-  const requestLabelChange = (newLabelList: number[]) =>
+  const requestLabelChange = (newLabelList: number[]) => {
     updateTaskInformation({
       nodeFrom: selectedNode!.nodeId,
-      dataFrom: { changed: { labelIds: JSON.stringify(newLabelList) } },
+      dataFrom: { changed: { labelIds: selectedNode!.labelIds ? selectedNode!.labelIds : '[]' } },
       dataTo: { changed: { labelIds: JSON.stringify(newLabelList) } },
     });
+  };
 
   if (!selectedNode) {
     return null;

--- a/client/src/components/templates/ProjectCardContainer/index.tsx
+++ b/client/src/components/templates/ProjectCardContainer/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { ProjectCard } from 'components/organisms';
 import { NewProjectModalWrapper } from 'components/templates';
 import useCustomHistory from 'hooks/useCustomHistory';
+import useModal from 'hooks/useModal';
 import useToast from 'hooks/useToast';
 import { IProject } from 'pages/Project';
 import { API } from 'utils/api';
@@ -20,6 +21,7 @@ interface IProps {
 }
 
 const ProjectCardContainer: React.FC<IProps> = ({ projectList, setProjectList }) => {
+  const { showModal, hideModal } = useModal();
   const { showMessage } = useToast();
   const { historyPush } = useCustomHistory();
 
@@ -30,8 +32,19 @@ const ProjectCardContainer: React.FC<IProps> = ({ projectList, setProjectList })
   };
   const handleClickTrashButton = (event: React.MouseEvent<HTMLButtonElement>, projectId: string) => {
     event.stopPropagation();
-    setProjectList((list) => list.filter((p) => p.id !== projectId));
-    API.project.delete(projectId);
+    showModal({
+      modalType: 'confirmModal',
+      modalProps: {
+        title: '프로젝트 삭제',
+        text: `프로젝트를 삭제합니다`,
+        onClickSubmitButton: () => {
+          setProjectList((list) => list.filter((p) => p.id !== projectId));
+          API.project.delete(projectId);
+          hideModal();
+        },
+        onCancelButton: hideModal,
+      },
+    });
   };
   const handleClickProjectCard = (projectId: string) => {
     historyPush(`mindmap`, projectId);

--- a/client/src/hooks/useAuthentication/index.ts
+++ b/client/src/hooks/useAuthentication/index.ts
@@ -1,14 +1,14 @@
 import { useEffect } from 'react';
-import { useRecoilState, useSetRecoilState } from 'recoil';
-import useCumstomHistory from 'hooks/useCustomHistory';
+import { useSetRecoilState } from 'recoil';
+import useCustomHistory from 'hooks/useCustomHistory';
 import useToast from 'hooks/useToast';
 import { isAuthenticatedState, userState } from 'recoil/user';
 import { auth } from 'utils/api';
 
 const useAuthentication = () => {
-  const [isAuth, setIsAuth] = useRecoilState(isAuthenticatedState);
+  const setIsAuth = useSetRecoilState(isAuthenticatedState);
   const setUser = useSetRecoilState(userState);
-  const { redirectLogin } = useCumstomHistory();
+  const { redirectLogin } = useCustomHistory();
   const { showMessage } = useToast();
 
   const cleanAuthInfo = () => {
@@ -20,11 +20,9 @@ const useAuthentication = () => {
     try {
       const res = await auth.status();
       if (res.status === 200) {
-        if (!isAuth) {
-          const cacheUser = JSON.parse(localStorage.getItem('user')!);
-          setIsAuth(true);
-          setUser(cacheUser);
-        }
+        const cacheUser = JSON.parse(localStorage.getItem('user')!);
+        setIsAuth(true);
+        setUser(cacheUser);
       }
     } catch (err) {
       showMessage('로그인이 필요합니다.');


### PR DESCRIPTION
## 📑 제목
라벨 로그 이슈 + 뒤로가기 인증 이슈 해결

## 📎 관련 이슈
- #215 

## ✔️ 셀프 체크리스트
라벨의 로그가 각각 다른 결과를 가지게 한다.
프로젝트 페이지에 뒤로가기를 눌렀을 때 인증정보가 사라지는 이슈를 해결한다.
콘솔 확인하기

## 💬 작업 내용
라벨 로그 이슈 해결
UX 개선 드롭다운, 프로젝트 삭제 모달창

## 🚧 PR 특이 사항
프로젝트 페이지에만 뒤로가기 인증이 작용안했는데... 아마 헤더 라우터돔 쪽에서 사이드 이펙트가 난 것 같습니다.
거의 최종 마무리 일듯 합니다.

## 🕰 실제 소요 시간
1h